### PR TITLE
Fix to propagate provider action exceptions

### DIFF
--- a/AuthJanitor.Providers/ProviderManagerService.cs
+++ b/AuthJanitor.Providers/ProviderManagerService.cs
@@ -192,12 +192,19 @@ namespace AuthJanitor.Providers
             string anyFailureExceptionMessage)
             where TProviderType : IAuthJanitorProvider
         {
-            var providerActions = providers.Select(p => providerAction(p)
-                .ContinueWith(t =>
+            var providerActions = providers.Select(async p =>
+            {
+                try
                 {
-                    logger.LogError(t.Exception, individualFailureErrorLogMessageTemplate, p.GetType().Name);
-                },
-                TaskContinuationOptions.OnlyOnFaulted));
+                    await providerAction(p);
+                }
+                catch (Exception exception)
+                {
+                    logger.LogError(exception, individualFailureErrorLogMessageTemplate, p.GetType().Name);
+
+                    throw;
+                }
+            });
 
             try
             {


### PR DESCRIPTION
The new code used a continuation to log task failures, but failed to propagate that exception and so the exception handling logic for `Task::WhenAll` would have never fired.

I'm choosing to switch to full async/await here and stop doing raw TPL continuations because in order to propagae the exception "cleanly" (e.g. maintain proper stack trace) from the continuation is a mess and `async` code generated by compiler will handle this properly in addition to being much easier to read/reason about.