### PR TITLE
Use System.Text.Json for serialization

### DIFF
--- a/AuthJanitor.Automation.Shared/AuthJanitor.Automation.Shared.csproj
+++ b/AuthJanitor.Automation.Shared/AuthJanitor.Automation.Shared.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AuthJanitor.Automation.Shared/AuthJanitorHttpClient.cs
+++ b/AuthJanitor.Automation.Shared/AuthJanitorHttpClient.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Automation.Shared.ViewModels;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Automation.Shared
@@ -14,6 +13,13 @@ namespace AuthJanitor.Automation.Shared
     {
         public const string HEADER_NAME = "AuthJanitor";
         public const string HEADER_VALUE = "administrator";
+
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions()
+        {
+            WriteIndented = false,
+            IgnoreNullValues = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
 
         private static readonly Dictionary<Type, string> ApiFormatStrings = new Dictionary<Type, string>()
         {
@@ -27,6 +33,7 @@ namespace AuthJanitor.Automation.Shared
 
         public AuthJanitorHttpClient() : base()
         {
+            SerializerOptions.Converters.Add(new TimeSpanConverter());
             if (!DefaultRequestHeaders.Contains(HEADER_NAME))
                 DefaultRequestHeaders.Add(HEADER_NAME, HEADER_VALUE);
         }
@@ -93,13 +100,7 @@ namespace AuthJanitor.Automation.Shared
             return this;
         }
 
-        private string Serialize<T>(T obj) =>
-            JsonConvert.SerializeObject(obj, new JsonSerializerSettings()
-            {
-                Formatting = Formatting.None,
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-        private T Deserialize<T>(string str) =>
-            JsonConvert.DeserializeObject<T>(str);
+        private string Serialize<T>(T obj) => JsonSerializer.Serialize(obj);
+        private T Deserialize<T>(string str) => JsonSerializer.Deserialize<T>(str);
     }
 }

--- a/AuthJanitor.Automation.Shared/AuthJanitorHttpClient.cs
+++ b/AuthJanitor.Automation.Shared/AuthJanitorHttpClient.cs
@@ -100,7 +100,7 @@ namespace AuthJanitor.Automation.Shared
             return this;
         }
 
-        private string Serialize<T>(T obj) => JsonSerializer.Serialize(obj);
-        private T Deserialize<T>(string str) => JsonSerializer.Deserialize<T>(str);
+        private string Serialize<T>(T obj) => JsonSerializer.Serialize(obj, SerializerOptions);
+        private T Deserialize<T>(string str) => JsonSerializer.Deserialize<T>(str, SerializerOptions);
     }
 }

--- a/AuthJanitor.Automation.Shared/AuthJanitorHttpClient.cs
+++ b/AuthJanitor.Automation.Shared/AuthJanitorHttpClient.cs
@@ -18,7 +18,8 @@ namespace AuthJanitor.Automation.Shared
         {
             WriteIndented = false,
             IgnoreNullValues = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new TimeSpanConverter() }
         };
 
         private static readonly Dictionary<Type, string> ApiFormatStrings = new Dictionary<Type, string>()
@@ -33,7 +34,6 @@ namespace AuthJanitor.Automation.Shared
 
         public AuthJanitorHttpClient() : base()
         {
-            SerializerOptions.Converters.Add(new TimeSpanConverter());
             if (!DefaultRequestHeaders.Contains(HEADER_NAME))
                 DefaultRequestHeaders.Add(HEADER_NAME, HEADER_VALUE);
         }

--- a/AuthJanitor.Automation.Shared/MetaServices/TaskExecutionMetaService.cs
+++ b/AuthJanitor.Automation.Shared/MetaServices/TaskExecutionMetaService.cs
@@ -20,7 +20,8 @@ namespace AuthJanitor.Automation.Shared.MetaServices
     {
         private static readonly JsonSerializerOptions ExceptionSerializerOptions = new JsonSerializerOptions()
         {
-            WriteIndented = true
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
 
         private readonly IDataStore<ManagedSecret> _managedSecrets;

--- a/AuthJanitor.Automation.Shared/MetaServices/TaskExecutionMetaService.cs
+++ b/AuthJanitor.Automation.Shared/MetaServices/TaskExecutionMetaService.cs
@@ -8,16 +8,21 @@ using AuthJanitor.Integrations.SecureStorage;
 using AuthJanitor.Providers;
 using AuthJanitor.Shared;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Automation.Shared.MetaServices
 {
     public class TaskExecutionMetaService
     {
+        private static readonly JsonSerializerOptions ExceptionSerializerOptions = new JsonSerializerOptions()
+        {
+            WriteIndented = true
+        };
+
         private readonly IDataStore<ManagedSecret> _managedSecrets;
         private readonly IDataStore<RekeyingTask> _rekeyingTasks;
         private readonly IDataStore<Resource> _resources;
@@ -185,7 +190,7 @@ namespace AuthJanitor.Automation.Shared.MetaServices
         {
             var myAttempt = task.Attempts.OrderByDescending(a => a.AttemptStarted).First();
             if (text != default) myAttempt.LogCritical(ex, text);
-            myAttempt.OuterException = JsonConvert.SerializeObject(ex, Formatting.Indented);
+            myAttempt.OuterException = JsonSerializer.Serialize(ex, ExceptionSerializerOptions);
             task.RekeyingInProgress = false;
             task.RekeyingFailed = true;
             await _rekeyingTasks.Update(task);

--- a/AuthJanitor.Automation.Shared/Models/ManagedSecret.cs
+++ b/AuthJanitor.Automation.Shared/Models/ManagedSecret.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Integrations.DataStores;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace AuthJanitor.Automation.Shared.Models
 {

--- a/AuthJanitor.Automation.Shared/TimeSpanConverter.cs
+++ b/AuthJanitor.Automation.Shared/TimeSpanConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace AuthJanitor.Automation.Shared
 {
-    public sealed class TimeSpanConverter : JsonConverter<TimeSpan>
+    internal sealed class TimeSpanConverter : JsonConverter<TimeSpan>
     {
         public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/AuthJanitor.Automation.Shared/TimeSpanConverter.cs
+++ b/AuthJanitor.Automation.Shared/TimeSpanConverter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AuthJanitor.Automation.Shared
+{
+    public sealed class TimeSpanConverter : JsonConverter<TimeSpan>
+    {
+        public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return TimeSpan.Parse(reader.GetString());
+        }
+
+        public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/AuthJanitor.Automation.Shared/ViewModels/ManagedSecretViewModel.cs
+++ b/AuthJanitor.Automation.Shared/ViewModels/ManagedSecretViewModel.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace AuthJanitor.Automation.Shared.ViewModels
 {

--- a/AuthJanitor.Automation.Shared/ViewModels/ProviderConfigurationItemViewModel.cs
+++ b/AuthJanitor.Automation.Shared/ViewModels/ProviderConfigurationItemViewModel.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace AuthJanitor.Automation.Shared.ViewModels
 {

--- a/AuthJanitor.Integrations.DataStores.AzureBlobStorage/AzureBlobStorageDataStore.cs
+++ b/AuthJanitor.Integrations.DataStores.AzureBlobStorage/AzureBlobStorageDataStore.cs
@@ -5,13 +5,12 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Integrations.DataStores.AzureBlobStorage
@@ -118,7 +117,7 @@ namespace AuthJanitor.Integrations.DataStores.AzureBlobStorage
                     var etag = (await Blob.GetPropertiesAsync())?.Value?.ETag;
                     using (var ms = new MemoryStream())
                     {
-                        var serialized = JsonConvert.SerializeObject(CachedCollection, Formatting.None);
+                        var serialized = JsonSerializer.Serialize(CachedCollection);
                         ms.Write(Encoding.UTF8.GetBytes(serialized));
                         ms.Seek(0, SeekOrigin.Begin);
                         Blob.Upload(ms, conditions: new BlobRequestConditions() { IfMatch = etag });
@@ -147,7 +146,7 @@ namespace AuthJanitor.Integrations.DataStores.AzureBlobStorage
                 blobText.Value.Content.CopyTo(ms);
                 ms.Seek(0, SeekOrigin.Begin);
                 var str = Encoding.UTF8.GetString(ms.ToArray());
-                CachedCollection = JsonConvert.DeserializeObject<List<TStoredModel>>(str);
+                CachedCollection = JsonSerializer.Deserialize<List<TStoredModel>>(str);
             }
         }
 

--- a/AuthJanitor.Integrations.IdentityServices.AzureActiveDirectory/AzureADIdentityService.cs
+++ b/AuthJanitor.Integrations.IdentityServices.AzureActiveDirectory/AzureADIdentityService.cs
@@ -5,12 +5,12 @@ using Azure.Core;
 using Azure.Identity;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Integrations.IdentityServices.AzureActiveDirectory
@@ -144,7 +144,7 @@ namespace AuthJanitor.Integrations.IdentityServices.AzureActiveDirectory
                 Configuration.TenantId +
                 "/oauth2/token",
                 new FormUrlEncodedContent(dict));
-            var tokenResponse = JsonConvert.DeserializeObject<AccessTokenCredential>(
+            var tokenResponse = JsonSerializer.Deserialize<AccessTokenCredential>(
                 await result.Content.ReadAsStringAsync());
 
             return tokenResponse;

--- a/AuthJanitor.Providers/AuthJanitor.Providers.csproj
+++ b/AuthJanitor.Providers/AuthJanitor.Providers.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AuthJanitor.Providers/AuthJanitorProvider.cs
+++ b/AuthJanitor.Providers/AuthJanitorProvider.cs
@@ -3,10 +3,10 @@
 using AuthJanitor.Shared;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers
@@ -76,7 +76,7 @@ namespace AuthJanitor.Providers
         /// </summary>
         public TConfiguration Configuration
         {
-            get => _cachedConfigurationInstance ??= JsonConvert.DeserializeObject<TConfiguration>(SerializedConfiguration);
+            get => _cachedConfigurationInstance ??= JsonSerializer.Deserialize<TConfiguration>(SerializedConfiguration);
         }
 
         /// <summary>

--- a/AuthJanitor.Providers/ProviderManagerService.cs
+++ b/AuthJanitor.Providers/ProviderManagerService.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers
@@ -67,7 +67,7 @@ namespace AuthJanitor.Providers
         }
 
         public AuthJanitorProviderConfiguration GetProviderConfiguration(string name) => ActivatorUtilities.CreateInstance(_serviceProvider, GetProviderMetadata(name).ProviderConfigurationType) as AuthJanitorProviderConfiguration;
-        public AuthJanitorProviderConfiguration GetProviderConfiguration(string name, string serializedConfiguration) => JsonConvert.DeserializeObject(serializedConfiguration, GetProviderMetadata(name).ProviderConfigurationType) as AuthJanitorProviderConfiguration;
+        public AuthJanitorProviderConfiguration GetProviderConfiguration(string name, string serializedConfiguration) => JsonSerializer.Deserialize(serializedConfiguration, GetProviderMetadata(name).ProviderConfigurationType) as AuthJanitorProviderConfiguration;
         public IReadOnlyList<LoadedProviderMetadata> LoadedProviders { get; }
 
         public async Task ExecuteRekeyingWorkflow(

--- a/AuthJanitor.Providers/RekeyingAttemptLogger.cs
+++ b/AuthJanitor.Providers/RekeyingAttemptLogger.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 namespace AuthJanitor.Providers

--- a/AuthJanitor.Shared/AccessTokenCredential.cs
+++ b/AuthJanitor.Shared/AccessTokenCredential.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-using Newtonsoft.Json;
 using System;
+using System.Text.Json.Serialization;
 
 namespace AuthJanitor.Shared
 {
@@ -9,15 +9,15 @@ namespace AuthJanitor.Shared
     {
         public string Username { get; set; }
 
-        [JsonProperty("access_token")]
+        [JsonPropertyName("access_token")]
         public string AccessToken { get; set; }
 
-        [JsonProperty("expires_in")]
+        [JsonPropertyName("expires_in")]
         public int ExpiresIn { get; set; }
 
         public TimeSpan ExpiresInTimeSpan => TimeSpan.FromSeconds(ExpiresIn);
 
-        [JsonProperty("expires_on")]
+        [JsonPropertyName("expires_on")]
         public long ExpiresOn { get; set; }
 
         public DateTimeOffset ExpiresOnDateTime
@@ -26,7 +26,7 @@ namespace AuthJanitor.Shared
             set => ExpiresOn = value.ToUnixTimeSeconds();
         }
 
-        [JsonProperty("ext_expires_in")]
+        [JsonPropertyName("ext_expires_in")]
         public int ExtExpiresIn { get; set; }
 
         public TimeSpan ExtExpiresInTimeSpan
@@ -35,7 +35,7 @@ namespace AuthJanitor.Shared
             set => ExtExpiresIn = (int)value.TotalSeconds;
         }
 
-        [JsonProperty("not_before")]
+        [JsonPropertyName("not_before")]
         public long NotBefore { get; set; }
 
         public DateTimeOffset NotBeforeDateTime
@@ -44,16 +44,16 @@ namespace AuthJanitor.Shared
             set => NotBefore = value.ToUnixTimeSeconds();
         }
 
-        [JsonProperty("refresh_token")]
+        [JsonPropertyName("refresh_token")]
         public string RefreshToken { get; set; }
 
-        [JsonProperty("resource")]
+        [JsonPropertyName("resource")]
         public string Resource { get; set; }
 
-        [JsonProperty("scope")]
+        [JsonPropertyName("scope")]
         public string Scope { get; set; }
 
-        [JsonProperty("token_type")]
+        [JsonPropertyName("token_type")]
         public string TokenType { get; set; }
     }
 }

--- a/AuthJanitor.Shared/AuthJanitor.Shared.csproj
+++ b/AuthJanitor.Shared/AuthJanitor.Shared.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Switch from Newtonsoft.Json to System.Text.Json Fixes #25 
(Note that we still inherit a dependency to this via `Microsoft.Rest.ClientRuntime`, a part of the Fluent AzureRM management packages)

Move any settings into fields; add TimeSpanConverter. Fixes #22 