### PR TITLE
Add test buttons to settings card

### DIFF
--- a/AuthJanitor.Automation.AdminUi/Pages/ManagedSecretDetail.razor
+++ b/AuthJanitor.Automation.AdminUi/Pages/ManagedSecretDetail.razor
@@ -73,5 +73,10 @@
     protected override async Task OnInitializedAsync()
     {
         Secret = await Http.AJGet<ManagedSecretViewModel>(Guid.Parse(SecretId));
+        await Task.WhenAll(Secret.Resources.Select(async resource =>
+        {
+            resource.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(resource.ProviderType);
+            resource.ProviderConfiguration.SerializedConfiguration = resource.SerializedProviderConfiguration;
+        }));
     }
 }

--- a/AuthJanitor.Automation.AdminUi/Pages/ManagedSecrets.razor
+++ b/AuthJanitor.Automation.AdminUi/Pages/ManagedSecrets.razor
@@ -103,7 +103,15 @@
 
     protected override Task OnInitializedAsync() => LoadData();
 
-    protected async Task LoadData() => Secrets = await Http.AJList<ManagedSecretViewModel>();
+    protected async Task LoadData()
+    {
+        Secrets = await Http.AJList<ManagedSecretViewModel>();
+        await Task.WhenAll(Secrets.SelectMany(s => s.Resources).Distinct().Select(async resource =>
+        {
+            resource.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(resource.ProviderType);
+            resource.ProviderConfiguration.SerializedConfiguration = resource.SerializedProviderConfiguration;
+        }));
+    }
 
     protected void CreateNew()
     {

--- a/AuthJanitor.Automation.AdminUi/Pages/RekeyingTaskDetail.razor
+++ b/AuthJanitor.Automation.AdminUi/Pages/RekeyingTaskDetail.razor
@@ -131,6 +131,12 @@
         Task = await Http.AJGet<RekeyingTaskViewModel>(Guid.Parse(RekeyingTaskId));
         if (Task.Attempts.Any())
             SelectedAttemptTab = Task.Attempts.OrderByDescending(a => a.AttemptStarted).FirstOrDefault()?.AttemptStarted.ToString();
+        
+        await System.Threading.Tasks.Task.WhenAll(Task.ManagedSecret.Resources.Select(async resource =>
+        {
+            resource.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(resource.ProviderType);
+            resource.ProviderConfiguration.SerializedConfiguration = resource.SerializedProviderConfiguration;
+        }));
     }
 
     string SelectedAttemptTab;

--- a/AuthJanitor.Automation.AdminUi/Pages/ResourceDetail.razor
+++ b/AuthJanitor.Automation.AdminUi/Pages/ResourceDetail.razor
@@ -16,7 +16,9 @@
         </Row>
         <Row>
             <Column Margin="Margin.Is1.OnY" ColumnSize="ColumnSize.Is12">
-                <ProviderSettingsCard ProviderConfiguration="@ProviderConfiguration" ShowEditControls="false" />
+                <ProviderSettingsCard ProviderConfiguration="@Resource.ProviderConfiguration" 
+                                      ProviderType="@Resource.ProviderType"
+                                      ShowEditControls="false" />
             </Column>
         </Row>
         <Row>
@@ -37,12 +39,10 @@
 
     public ResourceViewModel Resource { get; set; } = new ResourceViewModel();
 
-    protected ProviderConfigurationViewModel ProviderConfiguration { get; set; }
-
     protected override async Task OnInitializedAsync()
     {
         Resource = await Http.AJGet<ResourceViewModel>(Guid.Parse(ResourceId));
-        ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(Resource.ProviderType);
-        ProviderConfiguration.SerializedConfiguration = Resource.SerializedProviderConfiguration;
+        Resource.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(Resource.ProviderType);
+        Resource.ProviderConfiguration.SerializedConfiguration = Resource.SerializedProviderConfiguration;
     }
 }

--- a/AuthJanitor.Automation.AdminUi/Pages/Resources.razor
+++ b/AuthJanitor.Automation.AdminUi/Pages/Resources.razor
@@ -58,8 +58,7 @@
            YesButton="Create"
            NoButton="Cancel"
            ResultClicked="@CreateCallback">
-    <ResourceEditor @bind-Value="@SelectedValue"
-                    @ref="_resourceEditorRef"/>
+    <ResourceEditor @bind-Value="@SelectedValue"/>
 </DataModal>
 <DeleteConfirmationModal @bind-Visible="@DeleteModalShowing"
                          ObjectId="@SelectedValue.ObjectId"
@@ -83,7 +82,15 @@
 
     protected override Task OnInitializedAsync() => LoadData();
 
-    protected async Task LoadData() => ManagedResources = await Http.AJList<ResourceViewModel>();
+    protected async Task LoadData()
+    {
+        ManagedResources = await Http.AJList<ResourceViewModel>();
+        await Task.WhenAll(ManagedResources.Select(async resource =>
+        {
+            resource.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(resource.ProviderType);
+            resource.ProviderConfiguration.SerializedConfiguration = resource.SerializedProviderConfiguration;
+        }));
+    }
 
     protected void CreateNew()
     {
@@ -95,7 +102,7 @@
     {
         if (result)
         {
-            SelectedValue.SerializedProviderConfiguration = _resourceEditorRef.ProviderConfiguration?.SerializedConfiguration;
+            SelectedValue.SerializedProviderConfiguration = SelectedValue.ProviderConfiguration?.SerializedConfiguration;
             await Http.AJCreate<ResourceViewModel>(SelectedValue);
             await LoadData();
         }

--- a/AuthJanitor.Automation.Components/Cards/ProviderSettingsCard.razor
+++ b/AuthJanitor.Automation.Components/Cards/ProviderSettingsCard.razor
@@ -1,5 +1,23 @@
 ﻿<Card>
-    <CardHeader Class="text-info">Provider Settings</CardHeader>
+    <CardHeader Class="text-info">
+        <Row>
+            <Column ColumnSize="ColumnSize.Is6" Padding="Padding.Is2.FromTop">
+                Provider Settings
+            </Column>
+            <Column ColumnSize="ColumnSize.Is3" Class="text-right">
+                <ConfigurationTestButton ProviderType="@ProviderType"
+                                         ProviderConfiguration="@ProviderConfiguration"
+                                         DefaultColor="Color.Secondary"
+                                         Context="TestAsContexts.AsUser" />
+            </Column>
+            <Column ColumnSize="ColumnSize.Is3" Class="text-right">
+                <ConfigurationTestButton ProviderType="@ProviderType"
+                                         ProviderConfiguration="@ProviderConfiguration"
+                                         DefaultColor="Color.Secondary"
+                                         Context="TestAsContexts.AsApp" />
+            </Column>
+        </Row>
+    </CardHeader>
     <CardBody Padding="Padding.Is0">
         <ConfigurationVisualizer @bind-ShowEditControls="@ShowEditControls"
                                  @bind-Value="@ProviderConfiguration" />
@@ -13,6 +31,9 @@
 
     [Parameter]
     public EventCallback<ProviderConfigurationViewModel> ProviderConfigurationChanged { get; set; }
+
+    [Parameter]
+    public string ProviderType { get; set; }
 
     [Parameter]
     public bool ShowEditControls { get; set; } = false;

--- a/AuthJanitor.Automation.Components/Cards/ResourceListCardAccordion.razor
+++ b/AuthJanitor.Automation.Components/Cards/ResourceListCardAccordion.razor
@@ -1,6 +1,4 @@
 ﻿<Accordion>
-    @if (ConfigurationReady)
-    {
     @foreach (var resource in Resources)
     {
         <Card>
@@ -15,7 +13,9 @@
                     <Container IsFluid="true">
                         <Row>
                             <Column Margin="Margin.Is1.OnY" ColumnSize="ColumnSize.Is12">
-                                <ProviderSettingsCard ProviderConfiguration="@ProviderConfigurations[resource.ObjectId]" ShowEditControls="false" />
+                                <ProviderSettingsCard ProviderConfiguration="@resource.ProviderConfiguration" 
+                                                      ProviderType="@resource.ProviderType"
+                                                      ShowEditControls="false" />
                             </Column>
                         </Row>
                         <Row>
@@ -31,37 +31,21 @@
             </Collapse>
         </Card>
     }
-    }
 </Accordion>
 
 @using AuthJanitor.Automation.Components.Common.Resources
 @using AuthJanitor.Automation.Components.Common.Risks
 @code {
     protected Dictionary<Guid, bool> Visibilities { get; set; } = new Dictionary<Guid, bool>();
-    protected Dictionary<Guid, ProviderConfigurationViewModel> ProviderConfigurations { get; set; } = new Dictionary<Guid, ProviderConfigurationViewModel>();
 
     [Parameter]
     public IEnumerable<ResourceViewModel> Resources { get; set; } = new List<ResourceViewModel>();
-
-    protected bool ConfigurationReady { get; set; } = false;
 
     protected override void OnParametersSet()
     {
         foreach (var r in Resources)
         {
             Visibilities[r.ObjectId] = false;
-            ProviderConfigurations[r.ObjectId] = new ProviderConfigurationViewModel();
         }
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        await Task.WhenAll(Resources.Select(async r =>
-        {
-            Visibilities[r.ObjectId] = false;
-            var providerConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(r.ProviderType);
-            ProviderConfigurations[r.ObjectId].ConfigurationItems = providerConfiguration.ConfigurationItems;
-            ProviderConfigurations[r.ObjectId].SerializedConfiguration = r.SerializedProviderConfiguration;
-        })).ContinueWith(t => ConfigurationReady = true);
     }
 }

--- a/AuthJanitor.Automation.Components/Editors/ResourceEditor.razor
+++ b/AuthJanitor.Automation.Components/Editors/ResourceEditor.razor
@@ -24,14 +24,14 @@
         </Field>
     </Row>
 </Container>
-@if (ProviderConfiguration != null &&
-    ProviderConfiguration.ConfigurationItems != null &&
-    ProviderConfiguration.ConfigurationItems.Any())
+@if (Value.ProviderConfiguration != null &&
+    Value.ProviderConfiguration.ConfigurationItems != null &&
+    Value.ProviderConfiguration.ConfigurationItems.Any())
 {
     <Container Class="hasSectionHeader">
         <span class="sectionHeader">Provider Settings</span>
         <Row>
-            <ConfigurationVisualizer @bind-Value="@ProviderConfiguration"
+            <ConfigurationVisualizer @bind-Value="@Value.ProviderConfiguration"
                                       ShowEditControls="true" />
         </Row>
     </Container>
@@ -44,13 +44,13 @@
         </Paragraph>
         <Column ColumnSize="ColumnSize.Is6" Class="text-center">
             <ConfigurationTestButton ProviderType="@Value.ProviderType"
-                                     ProviderConfiguration="@ProviderConfiguration"
+                                     ProviderConfiguration="@Value.ProviderConfiguration"
                                      DefaultColor="Color.Secondary"
                                      Context="TestAsContexts.AsUser" />
         </Column>
         <Column ColumnSize="ColumnSize.Is6" Class="text-center">
             <ConfigurationTestButton ProviderType="@Value.ProviderType"
-                                     ProviderConfiguration="@ProviderConfiguration"
+                                     ProviderConfiguration="@Value.ProviderConfiguration"
                                      DefaultColor="Color.Secondary"
                                      Context="TestAsContexts.AsApp" />
         </Column>
@@ -65,11 +65,9 @@
     [Parameter]
     public EventCallback<ResourceViewModel> ValueChanged { get; set; }
 
-    public ProviderConfigurationViewModel ProviderConfiguration { get; set; }
-
     protected async Task ProviderTypeChanged(string providerType)
     {
         Value.ProviderType = providerType;
-        ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(providerType);
+        Value.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(providerType);
     }
 }

--- a/AuthJanitor.Automation.Shared/ViewModels/ResourceViewModel.cs
+++ b/AuthJanitor.Automation.Shared/ViewModels/ResourceViewModel.cs
@@ -4,6 +4,7 @@ using AuthJanitor.Providers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace AuthJanitor.Automation.Shared.ViewModels
 {
@@ -26,5 +27,9 @@ namespace AuthJanitor.Automation.Shared.ViewModels
         public IEnumerable<RiskyConfigurationItem> Risks { get; set; } = new List<RiskyConfigurationItem>();
         public string RuntimeDescription { get; set; }
         public int RiskScore => Risks.Sum(r => r.Score);
+
+        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        public ProviderConfigurationViewModel ProviderConfiguration { get; set; } = new ProviderConfigurationViewModel();
     }
 }


### PR DESCRIPTION
Adds provider config test buttons to card, so config can be tested prior to creation as well as after record has been created.