### PR TITLE
Switch to SecureString for RegeneratedSecret

### DIFF
--- a/AuthJanitor.Automation.AdminApi/ManagedSecrets.cs
+++ b/AuthJanitor.Automation.AdminApi/ManagedSecrets.cs
@@ -78,7 +78,7 @@ namespace AuthJanitor.Automation.AdminApi
                 LastChanged = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(inputSecret.ValidPeriodMinutes),
                 TaskConfirmationStrategies = inputSecret.TaskConfirmationStrategies,
                 ResourceIds = resourceIds,
-                Nonce = await _cryptographicImplementation.GenerateCryptographicallySecureString(_configuration.DefaultNonceLength)
+                Nonce = await _cryptographicImplementation.GenerateCryptographicallyRandomString(_configuration.DefaultNonceLength)
             };
 
             await _managedSecrets.Create(newManagedSecret);
@@ -165,7 +165,7 @@ namespace AuthJanitor.Automation.AdminApi
                 ValidPeriod = TimeSpan.FromMinutes(inputSecret.ValidPeriodMinutes),
                 TaskConfirmationStrategies = inputSecret.TaskConfirmationStrategies,
                 ResourceIds = resourceIds,
-                Nonce = await _cryptographicImplementation.GenerateCryptographicallySecureString(_configuration.DefaultNonceLength)
+                Nonce = await _cryptographicImplementation.GenerateCryptographicallyRandomString(_configuration.DefaultNonceLength)
             };
 
             await _managedSecrets.Update(newManagedSecret);

--- a/AuthJanitor.Integrations/CryptographicImplementations/Extensions.cs
+++ b/AuthJanitor.Integrations/CryptographicImplementations/Extensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace AuthJanitor.Integrations.CryptographicImplementations
+{
+    public static class Extensions
+    {
+        public static string GetNormalString(this SecureString str)
+        {
+            IntPtr bstr = Marshal.SecureStringToBSTR(str);
+            try { return Marshal.PtrToStringBSTR(bstr); }
+            finally { Marshal.ZeroFreeBSTR(bstr); }
+        }
+
+        /// <summary>
+        /// Retrieve a SecureString object. Note that the existence of "str" at all makes this
+        /// content inherently insecure in memory!
+        /// </summary>
+        /// <param name="str">String to convert</param>
+        /// <returns></returns>
+        public static SecureString GetSecureString(this string str)
+        {
+            var securePassword = new SecureString();
+            foreach (char c in str)
+                securePassword.AppendChar(c);
+            securePassword.MakeReadOnly();
+            return securePassword;
+        }
+    }
+}

--- a/AuthJanitor.Integrations/CryptographicImplementations/ICryptographicImplementation.cs
+++ b/AuthJanitor.Integrations/CryptographicImplementations/ICryptographicImplementation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+using System.Security;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Integrations.CryptographicImplementations
@@ -7,11 +8,18 @@ namespace AuthJanitor.Integrations.CryptographicImplementations
     public interface ICryptographicImplementation
     {
         /// <summary>
-        /// Generate a new secure string with a given length
+        /// Generate a new cryptographically random SecureString with a given length
+        /// </summary>
+        /// <param name="length">Length to generate</param>
+        /// <returns>Generated SecureString</returns>
+        Task<SecureString> GenerateCryptographicallyRandomSecureString(int length);
+
+        /// <summary>
+        /// Generate a new cryptographically random string with a given length
         /// </summary>
         /// <param name="length">Length to generate</param>
         /// <returns>Generated string</returns>
-        Task<string> GenerateCryptographicallySecureString(int length);
+        Task<string> GenerateCryptographicallyRandomString(int length);
 
         /// <summary>
         /// Hash a given string

--- a/AuthJanitor.Providers.AppServices/Functions/AppSettingsFunctionsApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/Functions/AppSettingsFunctionsApplicationLifecycleProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.AppService.Fluent;
 using Microsoft.Azure.Management.AppService.Fluent.WebAppBase.Update;
 using Microsoft.Extensions.Logging;
@@ -77,7 +78,7 @@ namespace AuthJanitor.Providers.AppServices.Functions
                     Configuration.CommitAsConnectionString ? "connection string" : "secret");
 
                 updateBase = updateBase.WithAppSetting(appSettingName,
-                    Configuration.CommitAsConnectionString ? secret.NewConnectionStringOrKey : secret.NewSecretValue);
+                    Configuration.CommitAsConnectionString ? secret.NewConnectionStringOrKey.GetNormalString() : secret.NewSecretValue.GetNormalString());
             }
 
             _logger.LogInformation("Applying changes.");

--- a/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.AppService.Fluent;
 using Microsoft.Azure.Management.AppService.Fluent.WebAppBase.Update;
 using Microsoft.Extensions.Logging;
@@ -73,7 +74,7 @@ namespace AuthJanitor.Providers.AppServices.Functions
                 var connectionStringName = string.IsNullOrEmpty(secret.UserHint) ? Configuration.ConnectionStringName : $"{Configuration.ConnectionStringName}-{secret.UserHint}";
                 _logger.LogInformation("Updating Connection String '{ConnectionStringName}' in slot '{SlotName}'", connectionStringName, TemporarySlotName);
                 updateBase = updateBase.WithoutConnectionString(connectionStringName);
-                updateBase = updateBase.WithConnectionString(connectionStringName, secret.NewConnectionStringOrKey, Configuration.ConnectionStringType);
+                updateBase = updateBase.WithConnectionString(connectionStringName, secret.NewConnectionStringOrKey.GetNormalString(), Configuration.ConnectionStringType);
             }
 
             _logger.LogInformation("Applying changes.");

--- a/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
@@ -42,7 +42,7 @@ namespace AuthJanitor.Providers.AppServices.Functions
             {
                 Expiry = DateTimeOffset.UtcNow + requestedValidPeriod,
                 UserHint = Configuration.UserHint,
-                NewSecretValue = await _cryptographicImplementation.GenerateCryptographicallySecureString(Configuration.KeyLength)
+                NewSecretValue = await _cryptographicImplementation.GenerateCryptographicallyRandomSecureString(Configuration.KeyLength)
             };
 
             var functionsApp = await (await this.GetAzure()).AppServices.FunctionApps.GetByResourceGroupAsync(ResourceGroup, ResourceName);
@@ -53,7 +53,7 @@ namespace AuthJanitor.Providers.AppServices.Functions
             await functionsApp.RemoveFunctionKeyAsync(Configuration.FunctionName, Configuration.FunctionKeyName);
 
             _logger.LogInformation("Adding new Function Key '{FunctionKeyName}' from Function '{FunctionName}'", Configuration.FunctionKeyName, Configuration.FunctionName);
-            await functionsApp.AddFunctionKeyAsync(Configuration.FunctionName, Configuration.FunctionKeyName, newKey.NewSecretValue);
+            await functionsApp.AddFunctionKeyAsync(Configuration.FunctionName, Configuration.FunctionKeyName, newKey.NewSecretValue.GetNormalString());
 
             return newKey;
         }

--- a/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.AppService.Fluent;
 using Microsoft.Azure.Management.AppService.Fluent.WebAppBase.Update;
 using Microsoft.Extensions.Logging;
@@ -74,7 +75,7 @@ namespace AuthJanitor.Providers.AppServices.WebApps
                     Configuration.CommitAsConnectionString ? "connection string" : "secret");
 
                 updateBase = updateBase.WithAppSetting(appSettingName,
-                    Configuration.CommitAsConnectionString ? secret.NewConnectionStringOrKey : secret.NewSecretValue);
+                    (Configuration.CommitAsConnectionString ? secret.NewConnectionStringOrKey : secret.NewSecretValue).GetNormalString());
             }
 
             _logger.LogInformation("Applying changes.");

--- a/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.AppService.Fluent;
 using Microsoft.Azure.Management.AppService.Fluent.WebAppBase.Update;
 using Microsoft.Extensions.Logging;
@@ -73,7 +74,7 @@ namespace AuthJanitor.Providers.AppServices.WebApps
                 var connectionStringName = string.IsNullOrEmpty(secret.UserHint) ? Configuration.ConnectionStringName : $"{Configuration.ConnectionStringName}-{secret.UserHint}";
                 _logger.LogInformation("Updating Connection String '{ConnectionStringName}' in slot '{SlotName}'", connectionStringName, slotName);
                 updateBase = updateBase.WithoutConnectionString(connectionStringName);
-                updateBase = updateBase.WithConnectionString(connectionStringName, secret.NewConnectionStringOrKey, Configuration.ConnectionStringType);
+                updateBase = updateBase.WithConnectionString(connectionStringName, secret.NewConnectionStringOrKey.GetNormalString(), Configuration.ConnectionStringType);
             }
 
             _logger.LogInformation("Applying changes.");

--- a/AuthJanitor.Providers.AzureAD/AccessTokenRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AzureAD/AccessTokenRekeyableObjectProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -36,7 +37,7 @@ namespace AuthJanitor.Providers.AzureAD
             return new RegeneratedSecret()
             {
                 UserHint = Configuration.UserHint,
-                NewSecretValue = token.Token,
+                NewSecretValue = token.Token.GetSecureString(),
                 Expiry = token.ExpiresOn
             };
         }

--- a/AuthJanitor.Providers.AzureAD/AuthJanitor.Providers.AzureAD.csproj
+++ b/AuthJanitor.Providers.AzureAD/AuthJanitor.Providers.AzureAD.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AuthJanitor.Extensions.Azure\AuthJanitor.Extensions.Azure.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations\AuthJanitor.Integrations.csproj" />
     <ProjectReference Include="..\AuthJanitor.Providers\AuthJanitor.Providers.csproj" />
   </ItemGroup>
 

--- a/AuthJanitor.Providers.AzureMaps/AuthJanitor.Providers.AzureMaps.csproj
+++ b/AuthJanitor.Providers.AzureMaps/AuthJanitor.Providers.AzureMaps.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AuthJanitor.Extensions.Azure\AuthJanitor.Extensions.Azure.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations\AuthJanitor.Integrations.csproj" />
     <ProjectReference Include="..\AuthJanitor.Providers\AuthJanitor.Providers.csproj" />
   </ItemGroup>
 

--- a/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.Maps;
 using Microsoft.Azure.Management.Maps.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers.AzureMaps
@@ -96,10 +98,10 @@ namespace AuthJanitor.Providers.AzureMaps
 
         private MapsManagementClient ManagementClient => new MapsManagementClient(Credential.CreateAzureCredentials());
 
-        private string GetKeyValue(MapsAccountKeys accountKeys, string keyType) => keyType switch
+        private SecureString GetKeyValue(MapsAccountKeys accountKeys, string keyType) => keyType switch
         {
-            PRIMARY_KEY => accountKeys.PrimaryKey,
-            SECONDARY_KEY => accountKeys.SecondaryKey,
+            PRIMARY_KEY => accountKeys.PrimaryKey.GetSecureString(),
+            SECONDARY_KEY => accountKeys.SecondaryKey.GetSecureString(),
             _ => throw new NotImplementedException()
         };
 

--- a/AuthJanitor.Providers.AzureSearch/AuthJanitor.Providers.AzureSearch.csproj
+++ b/AuthJanitor.Providers.AzureSearch/AuthJanitor.Providers.AzureSearch.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AuthJanitor.Extensions.Azure\AuthJanitor.Extensions.Azure.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations\AuthJanitor.Integrations.csproj" />
     <ProjectReference Include="..\AuthJanitor.Providers\AuthJanitor.Providers.csproj" />
   </ItemGroup>
 

--- a/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.Search.Fluent;
 using Microsoft.Azure.Management.Search.Fluent.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers.AzureSearch
@@ -103,10 +105,10 @@ namespace AuthJanitor.Providers.AzureSearch
             _ => throw new System.Exception($"Key kind '{keyKind}' not implemented")
         };
 
-        private string GetKeyValue(IAdminKeys keys, AdminKeyKind keyKind) => keyKind switch
+        private SecureString GetKeyValue(IAdminKeys keys, AdminKeyKind keyKind) => keyKind switch
         {
-            AdminKeyKind.Primary => keys.PrimaryKey,
-            AdminKeyKind.Secondary => keys.SecondaryKey,
+            AdminKeyKind.Primary => keys.PrimaryKey.GetSecureString(),
+            AdminKeyKind.Secondary => keys.SecondaryKey.GetSecureString(),
             _ => throw new System.Exception($"Key kind '{keyKind}' not implemented")
         };
     }

--- a/AuthJanitor.Providers.CosmosDb/AuthJanitor.Providers.CosmosDb.csproj
+++ b/AuthJanitor.Providers.CosmosDb/AuthJanitor.Providers.CosmosDb.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AuthJanitor.Extensions.Azure\AuthJanitor.Extensions.Azure.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations\AuthJanitor.Integrations.csproj" />
     <ProjectReference Include="..\AuthJanitor.Providers\AuthJanitor.Providers.csproj" />
   </ItemGroup>
 

--- a/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.CosmosDB.Fluent;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers.CosmosDb
@@ -112,12 +114,12 @@ namespace AuthJanitor.Providers.CosmosDb
             _ => throw new System.Exception($"KeyKind '{keyKind}' not implemented")
         };
 
-        private string GetKeyValue(IDatabaseAccountListKeysResult keys, CosmosDbKeyConfiguration.CosmosDbKeyKinds keyKind) => keyKind switch
+        private SecureString GetKeyValue(IDatabaseAccountListKeysResult keys, CosmosDbKeyConfiguration.CosmosDbKeyKinds keyKind) => keyKind switch
         {
-            CosmosDbKeyConfiguration.CosmosDbKeyKinds.Primary => keys.PrimaryMasterKey,
-            CosmosDbKeyConfiguration.CosmosDbKeyKinds.Secondary => keys.SecondaryMasterKey,
-            CosmosDbKeyConfiguration.CosmosDbKeyKinds.PrimaryReadOnly => keys.PrimaryReadonlyMasterKey,
-            CosmosDbKeyConfiguration.CosmosDbKeyKinds.SecondaryReadOnly => keys.SecondaryReadonlyMasterKey,
+            CosmosDbKeyConfiguration.CosmosDbKeyKinds.Primary => keys.PrimaryMasterKey.GetSecureString(),
+            CosmosDbKeyConfiguration.CosmosDbKeyKinds.Secondary => keys.SecondaryMasterKey.GetSecureString(),
+            CosmosDbKeyConfiguration.CosmosDbKeyKinds.PrimaryReadOnly => keys.PrimaryReadonlyMasterKey.GetSecureString(),
+            CosmosDbKeyConfiguration.CosmosDbKeyKinds.SecondaryReadOnly => keys.SecondaryReadonlyMasterKey.GetSecureString(),
             _ => throw new System.Exception($"KeyKind '{keyKind}' not implemented")
         };
     }

--- a/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.Eventhub.Fluent;
 using Microsoft.Azure.Management.EventHub.Fluent.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers.EventHub
@@ -109,16 +111,16 @@ namespace AuthJanitor.Providers.EventHub
             return authorizationRules.FirstOrDefault(r => r.Name == Configuration.AuthorizationRuleName);
         }
 
-        private string GetKeyValue(IEventHubAuthorizationKey keys, KeyType type) => type switch
+        private SecureString GetKeyValue(IEventHubAuthorizationKey keys, KeyType type) => type switch
         {
-            KeyType.SecondaryKey => keys.SecondaryKey,
-            _ => keys.PrimaryKey,
+            KeyType.SecondaryKey => keys.SecondaryKey.GetSecureString(),
+            _ => keys.PrimaryKey.GetSecureString(),
         };
 
-        private string GetConnectionStringValue(IEventHubAuthorizationKey keys, KeyType type) => type switch
+        private SecureString GetConnectionStringValue(IEventHubAuthorizationKey keys, KeyType type) => type switch
         {
-            KeyType.SecondaryKey => keys.SecondaryConnectionString,
-            _ => keys.PrimaryConnectionString,
+            KeyType.SecondaryKey => keys.SecondaryConnectionString.GetSecureString(),
+            _ => keys.PrimaryConnectionString.GetSecureString(),
         };
     }
 }

--- a/AuthJanitor.Providers.KeyVault/KeyVaultKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.KeyVault/KeyVaultKeyRekeyableObjectProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Azure.Security.KeyVault.Keys;
 using Microsoft.Extensions.Logging;
 using System;
@@ -33,7 +34,7 @@ namespace AuthJanitor.Providers.KeyVault
             return new RegeneratedSecret()
             {
                 UserHint = Configuration.UserHint,
-                NewSecretValue = currentKey.Value.Key.Id.ToString()
+                NewSecretValue = currentKey.Value.Key.Id.ToString().GetSecureString()
             };
         }
 
@@ -65,7 +66,7 @@ namespace AuthJanitor.Providers.KeyVault
             return new RegeneratedSecret()
             {
                 UserHint = Configuration.UserHint,
-                NewSecretValue = key.Value.Key.Id.ToString()
+                NewSecretValue = key.Value.Key.Id.ToString().GetSecureString()
             };
         }
 

--- a/AuthJanitor.Providers.KeyVault/KeyVaultSecretApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.KeyVault/KeyVaultSecretApplicationLifecycleProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Logging;
 using System;
@@ -36,7 +37,7 @@ namespace AuthJanitor.Providers.KeyVault
 
                 // Create a new version of the Secret
                 string secretName = string.IsNullOrEmpty(secret.UserHint) ? Configuration.SecretName : $"{Configuration.SecretName}-{secret.UserHint}";
-                KeyVaultSecret newKvSecret = new KeyVaultSecret(secretName, secret.NewSecretValue);
+                KeyVaultSecret newKvSecret = new KeyVaultSecret(secretName, secret.NewSecretValue.GetNormalString());
 
                 // Copy in metadata from the old Secret if it existed
                 if (currentSecret != null && currentSecret.Value != null)

--- a/AuthJanitor.Providers.KeyVault/KeyVaultSecretRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.KeyVault/KeyVaultSecretRekeyableObjectProvider.cs
@@ -38,7 +38,7 @@ namespace AuthJanitor.Providers.KeyVault
             {
                 Expiry = currentSecret.Value.Properties.ExpiresOn.Value,
                 UserHint = Configuration.UserHint,
-                NewSecretValue = currentSecret.Value.Value
+                NewSecretValue = currentSecret.Value.Value.GetSecureString()
             };
         }
 
@@ -51,7 +51,8 @@ namespace AuthJanitor.Providers.KeyVault
             // Create a new version of the Secret
             KeyVaultSecret newSecret = new KeyVaultSecret(
                 Configuration.SecretName,
-                await _cryptographicImplementation.GenerateCryptographicallySecureString(Configuration.SecretLength));
+                (await _cryptographicImplementation.GenerateCryptographicallyRandomSecureString(Configuration.SecretLength))
+                    .GetNormalString());
 
             // Copy in metadata from the old Secret if it existed
             if (currentSecret != null && currentSecret.Value != null)
@@ -74,7 +75,7 @@ namespace AuthJanitor.Providers.KeyVault
             {
                 Expiry = newSecret.Properties.ExpiresOn.Value,
                 UserHint = Configuration.UserHint,
-                NewSecretValue = secretResponse.Value.Value
+                NewSecretValue = secretResponse.Value.Value.GetSecureString()
             };
         }
         public override IList<RiskyConfigurationItem> GetRisks()

--- a/AuthJanitor.Providers.RedisCache/AuthJanitor.Providers.RedisCache.csproj
+++ b/AuthJanitor.Providers.RedisCache/AuthJanitor.Providers.RedisCache.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AuthJanitor.Extensions.Azure\AuthJanitor.Extensions.Azure.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations\AuthJanitor.Integrations.csproj" />
     <ProjectReference Include="..\AuthJanitor.Providers\AuthJanitor.Providers.csproj" />
   </ItemGroup>
 

--- a/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.Redis.Fluent;
 using Microsoft.Azure.Management.Redis.Fluent.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers.Redis
@@ -105,10 +107,10 @@ namespace AuthJanitor.Providers.Redis
             _ => throw new System.Exception($"Key type '{keyType}' not implemented")
         };
 
-        private string GetKeyValue(IRedisAccessKeys keys, RedisKeyType keyType) => keyType switch
+        private SecureString GetKeyValue(IRedisAccessKeys keys, RedisKeyType keyType) => keyType switch
         {
-            RedisKeyType.Primary => keys.PrimaryKey,
-            RedisKeyType.Secondary => keys.SecondaryKey,
+            RedisKeyType.Primary => keys.PrimaryKey.GetSecureString(),
+            RedisKeyType.Secondary => keys.SecondaryKey.GetSecureString(),
             _ => throw new System.Exception($"Key type '{keyType}' not implemented")
         };
     }

--- a/AuthJanitor.Providers.ServiceBus/AuthJanitor.Providers.ServiceBus.csproj
+++ b/AuthJanitor.Providers.ServiceBus/AuthJanitor.Providers.ServiceBus.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AuthJanitor.Extensions.Azure\AuthJanitor.Extensions.Azure.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations\AuthJanitor.Integrations.csproj" />
     <ProjectReference Include="..\AuthJanitor.Providers\AuthJanitor.Providers.csproj" />
   </ItemGroup>
 

--- a/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.ServiceBus.Fluent;
 using Microsoft.Azure.Management.ServiceBus.Fluent.Models;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace AuthJanitor.Providers.ServiceBus
@@ -108,16 +110,16 @@ namespace AuthJanitor.Providers.ServiceBus
         private Task<IServiceBusNamespace> ServiceBusNamespace => this.GetAzure().ContinueWith(az => az.Result.ServiceBusNamespaces.GetByResourceGroupAsync(ResourceGroup, ResourceName)).Unwrap();
         private Task<INamespaceAuthorizationRule> AuthorizationRule => ServiceBusNamespace.ContinueWith(ns => ns.Result.AuthorizationRules.GetByNameAsync(Configuration.AuthorizationRuleName)).Unwrap();
 
-        private string GetKeyValue(Policykey key, IAuthorizationKeys keys) => key switch
+        private SecureString GetKeyValue(Policykey key, IAuthorizationKeys keys) => key switch
         {
-            Policykey.SecondaryKey => keys.SecondaryKey,
-            _ => keys.PrimaryKey,
+            Policykey.SecondaryKey => keys.SecondaryKey.GetSecureString(),
+            _ => keys.PrimaryKey.GetSecureString(),
         };
 
-        private string GetConnectionStringValue(Policykey key, IAuthorizationKeys keys) => key switch
+        private SecureString GetConnectionStringValue(Policykey key, IAuthorizationKeys keys) => key switch
         {
-            Policykey.SecondaryKey => keys.SecondaryConnectionString,
-            _ => keys.PrimaryConnectionString,
+            Policykey.SecondaryKey => keys.SecondaryConnectionString.GetSecureString(),
+            _ => keys.PrimaryConnectionString.GetSecureString(),
         };
     }
 }

--- a/AuthJanitor.Providers.Storage/AuthJanitor.Providers.Storage.csproj
+++ b/AuthJanitor.Providers.Storage/AuthJanitor.Providers.Storage.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AuthJanitor.Extensions.Azure\AuthJanitor.Extensions.Azure.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations\AuthJanitor.Integrations.csproj" />
     <ProjectReference Include="..\AuthJanitor.Providers\AuthJanitor.Providers.csproj" />
   </ItemGroup>
 

--- a/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.Extensions.Azure;
+using AuthJanitor.Integrations.CryptographicImplementations;
 using Microsoft.Azure.Management.Storage.Fluent;
 using Microsoft.Azure.Management.Storage.Fluent.Models;
 using Microsoft.Extensions.Logging;
@@ -38,8 +39,8 @@ namespace AuthJanitor.Providers.Storage
             {
                 Expiry = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(10),
                 UserHint = Configuration.UserHint,
-                NewSecretValue = newKey?.Value,
-                NewConnectionString = $"DefaultEndpointsProtocol=https;AccountName={ResourceName};AccountKey={newKey?.Value};EndpointSuffix=core.windows.net"
+                NewSecretValue = newKey?.Value.GetSecureString(),
+                NewConnectionString = $"DefaultEndpointsProtocol=https;AccountName={ResourceName};AccountKey={newKey?.Value};EndpointSuffix=core.windows.net".GetSecureString()
             };
         }
 
@@ -52,8 +53,8 @@ namespace AuthJanitor.Providers.Storage
             {
                 Expiry = DateTimeOffset.UtcNow + requestedValidPeriod,
                 UserHint = Configuration.UserHint,
-                NewSecretValue = newKey?.Value,
-                NewConnectionString = $"DefaultEndpointsProtocol=https;AccountName={ResourceName};AccountKey={newKey?.Value};EndpointSuffix=core.windows.net"
+                NewSecretValue = newKey?.Value.GetSecureString(),
+                NewConnectionString = $"DefaultEndpointsProtocol=https;AccountName={ResourceName};AccountKey={newKey?.Value};EndpointSuffix=core.windows.net".GetSecureString()
             };
         }
 

--- a/AuthJanitor.Providers/RegeneratedSecret.cs
+++ b/AuthJanitor.Providers/RegeneratedSecret.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using System;
+using System.Security;
 
 namespace AuthJanitor.Providers
 {
@@ -12,17 +13,17 @@ namespace AuthJanitor.Providers
         /// <summary>
         /// Newly generated key
         /// </summary>
-        public string NewSecretValue { get; set; }
+        public SecureString NewSecretValue { get; set; }
 
         /// <summary>
         /// Newly generated connection string, if appropriate
         /// </summary>
-        public string NewConnectionString { get; set; }
+        public SecureString NewConnectionString { get; set; }
 
         /// <summary>
         /// Retrieve either the Connection String, or if that is not specified, the newly generated Key
         /// </summary>
-        public string NewConnectionStringOrKey => string.IsNullOrEmpty(NewConnectionString) ? NewSecretValue : NewConnectionString;
+        public SecureString NewConnectionStringOrKey => (NewConnectionString == null || NewConnectionString.Length == 0) ? NewSecretValue : NewConnectionString;
 
         /// <summary>
         /// Arbitrary user-specified hint string (from Provider Configuration) used to distinguish among multiple 


### PR DESCRIPTION
@ericmaino suggested using `SecureString` for the `RegeneratedSecret` so that we don't accidentally serialize sensitive information. I totally agree, and since `System.Security.SecureString` is now available in `netstandard2.1` it's usable.

Unfortunately the support for it in *other* libraries leaves a lot to be desired, so this PR also includes extension methods to transform back and forth between a SecureString and a string, understanding that doing so compromises in-memory confidentiality of the string.