### PR TITLE
Add local.settings.json

### DIFF
--- a/AuthJanitor.Automation.AdminApi/local.settings.json
+++ b/AuthJanitor.Automation.AdminApi/local.settings.json
@@ -1,0 +1,16 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+      "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+      
+      "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+      "AZURE_FUNCTION_PROXY_DISABLE_LOCAL_CALL": "True",  
+      "STORAGE_WEB_URL": "http://localhost:16010",
+  
+      "SENDGRID_API_KEY": "my.sendgrid.api.key",
+
+      "CLIENT_ID": "authjanitor-admin-application-client-id",
+      "CLIENT_SECRET": "authjanitor-admin-application-client-secret",
+      "TENANT_ID": "authjanitor-admin-application-tenant-id"
+    }
+  }

--- a/AuthJanitor.Automation.Agent/local.settings.json
+++ b/AuthJanitor.Automation.Agent/local.settings.json
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    
+    "SENDGRID_API_KEY": "my.sendgrid.api.key"
+  }
+}


### PR DESCRIPTION
Closes #62 

Note that we use `AZURE_FUNCTION_PROXY_DISABLE_LOCAL_CALL` to get around a limitation in Functions proxies *when developing locally*. This option should not be used in deployments.