### PR TITLE
Add provider feature flags, fill test gaps

### DIFF
--- a/AuthJanitor.Automation.Components/Cards/ProviderMetadataCard.razor
+++ b/AuthJanitor.Automation.Components/Cards/ProviderMetadataCard.razor
@@ -28,16 +28,25 @@
                     }
                 </CardText>
             </CardBody>
-            @if (!string.IsNullOrEmpty(Provider.Details.MoreInformationUrl))
-            {
-                <CardFooter>
-                    <a href="@Provider.Details.MoreInformationUrl" target="_blank">
-                        More Information...
-                        <Icon Name="FontAwesomeIcons.ExternalLinkAlt" Margin="Margin.Is2.FromLeft" />
-                    </a>
-                    <Button Color="Color.Secondary">More Information...</Button>
-                </CardFooter>
-            }
+            
+            <CardFooter Class="text-right border-left">
+                <Icon Name="FontAwesomeIcons.Flask"
+                      Class="@(Provider.Details.Features.HasFlag(ProviderFeatureFlags.IsTestable) ? "text-success" : "text-dark")"
+                      title="@("Provider " + (Provider.Details.Features.HasFlag(ProviderFeatureFlags.IsTestable) ? "Supports" : "Does Not Support") + " Pre-Testing")"
+                      Margin="Margin.Is2" />
+                <Icon Name="FontAwesomeIcons.SyncAlt"
+                      Class="@(Provider.Details.Features.HasFlag(ProviderFeatureFlags.CanRotateWithoutDowntime) ? "text-success" : "text-dark")"
+                      title="@("Provider " + (Provider.Details.Features.HasFlag(ProviderFeatureFlags.CanRotateWithoutDowntime) ? "Can" : "Cannot") + " Rotate Without Downtime")"
+                      Margin="Margin.Is2" />
+                <Icon Name="FontAwesomeIcons.LayerGroup"
+                      Class="@(Provider.Details.Features.HasFlag(ProviderFeatureFlags.HasCandidateSelection) ? "text-success" : "text-dark")"
+                      title="@("Provider " + (Provider.Details.Features.HasFlag(ProviderFeatureFlags.HasCandidateSelection) ? "Supports" : "Does Not Support") + " Candidate Selection")"
+                      Margin="Margin.Is2" />
+                <Icon Name="FontAwesomeIcons.Key"
+                      Class="@(Provider.Details.Features.HasFlag(ProviderFeatureFlags.SupportsSecondaryKey) ? "text-success" : "text-dark")"
+                      title="@("Provider " + (Provider.Details.Features.HasFlag(ProviderFeatureFlags.SupportsSecondaryKey) ? "Supports" : "Does Not Support") + " Use of a Secondary Key")"
+                      Margin="Margin.Is2" />
+            </CardFooter>
         </Column>
     </Row>
 </Card>

--- a/AuthJanitor.Automation.Shared/ViewModels/ResourceViewModel.cs
+++ b/AuthJanitor.Automation.Shared/ViewModels/ResourceViewModel.cs
@@ -20,8 +20,7 @@ namespace AuthJanitor.Automation.Shared.ViewModels
         {
             Name = "No Provider Loaded",
             Description = "No Provider Loaded",
-            IconClass = "fa fa-times",
-            MoreInformationUrl = string.Empty
+            IconClass = "fa fa-times"
         };
         public string SerializedProviderConfiguration { get; set; }
         public IEnumerable<RiskyConfigurationItem> Risks { get; set; } = new List<RiskyConfigurationItem>();

--- a/AuthJanitor.Providers.AppServices/Functions/AppSettingsFunctionsApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/Functions/AppSettingsFunctionsApplicationLifecycleProvider.cs
@@ -15,7 +15,9 @@ namespace AuthJanitor.Providers.AppServices.Functions
     /// </summary>
     [Provider(Name = "Functions App - AppSettings",
               IconClass = "fa fa-bolt",
-              Description = "Manages the lifecycle of an Azure Functions app which reads a Managed Secret from its Application Settings")]
+              Description = "Manages the lifecycle of an Azure Functions app which reads a Managed Secret from its Application Settings",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.FUNCTIONS_SVG)]
     public class AppSettingsFunctionsApplicationLifecycleProvider : FunctionsApplicationLifecycleProvider<AppSettingConfiguration>
     {

--- a/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
@@ -12,7 +12,9 @@ namespace AuthJanitor.Providers.AppServices.Functions
 {
     [Provider(Name = "Functions App - Connection String",
               IconClass = "fa fa-bolt",
-              Description = "Manages the lifecycle of an Azure Functions app which reads from a Connection String")]
+              Description = "Manages the lifecycle of an Azure Functions app which reads from a Connection String",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.FUNCTIONS_SVG)]
     public class ConnectionStringFunctionsApplicationLifecycleProvider : FunctionsApplicationLifecycleProvider<ConnectionStringConfiguration>
     {

--- a/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
@@ -10,7 +10,8 @@ namespace AuthJanitor.Providers.AppServices.Functions
 {
     [Provider(Name = "Functions App Key",
               IconClass = "fa fa-key",
-              Description = "Regenerates a Function Key for an Azure Functions application")]
+              Description = "Regenerates a Function Key for an Azure Functions application",
+              Features = ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.FUNCTIONS_SVG)]
     public class FunctionKeyRekeyableObjectProvider : RekeyableObjectProvider<FunctionKeyConfiguration>
     {

--- a/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
@@ -12,7 +12,9 @@ namespace AuthJanitor.Providers.AppServices.WebApps
 {
     [Provider(Name = "WebApp - AppSettings",
               IconClass = "fa fa-globe",
-              Description = "Manages the lifecycle of an Azure Web App which reads a Managed Secret from its Application Settings")]
+              Description = "Manages the lifecycle of an Azure Web App which reads a Managed Secret from its Application Settings",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.WEBAPPS_SVG)]
     public class AppSettingsWebAppApplicationLifecycleProvider : WebAppApplicationLifecycleProvider<AppSettingConfiguration>
     {

--- a/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
@@ -12,7 +12,9 @@ namespace AuthJanitor.Providers.AppServices.WebApps
 {
     [Provider(Name = "WebApp - Connection String",
               IconClass = "fa fa-globe",
-              Description = "Manages the lifecycle of an Azure Web App which reads from a Connection String")]
+              Description = "Manages the lifecycle of an Azure Web App which reads from a Connection String",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.WEBAPPS_SVG)]
     public class ConnectionStringWebAppApplicationLifecycleProvider : WebAppApplicationLifecycleProvider<ConnectionStringConfiguration>
     {

--- a/AuthJanitor.Providers.AzureAD/AccessTokenRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AzureAD/AccessTokenRekeyableObjectProvider.cs
@@ -10,7 +10,8 @@ namespace AuthJanitor.Providers.AzureAD
 {
     [Provider(Name = "Access Token",
               IconClass = "fa fa-key",
-              Description = "Acquires an Access Token from Azure AD with a given set of scopes")]
+              Description = "Acquires an Access Token from Azure AD with a given set of scopes",
+              Features = ProviderFeatureFlags.None)]
     [ProviderImage(ProviderImages.AZURE_AD_SVG)]
     public class AccessTokenRekeyableObjectProvider : RekeyableObjectProvider<AccessTokenConfiguration>
     {

--- a/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
@@ -12,7 +12,10 @@ namespace AuthJanitor.Providers.AzureMaps
 {
     [Provider(Name = "Azure Maps Key",
               IconClass = "fa fa-map",
-              Description = "Regenerates a key for an Azure Maps instance")]
+              Description = "Regenerates a key for an Azure Maps instance",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.AZURE_MAPS_SVG)]
     public class AzureMapsRekeyableObjectProvider : RekeyableObjectProvider<AzureMapsConfiguration>
     {
@@ -24,6 +27,14 @@ namespace AuthJanitor.Providers.AzureMaps
         public AzureMapsRekeyableObjectProvider(ILogger<AzureMapsRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var keys = await ManagementClient.Accounts.ListKeysAsync(
+                ResourceGroup,
+                ResourceName);
+            if (keys == null) throw new Exception("Could not access keys for Azure Maps");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
@@ -12,7 +12,10 @@ namespace AuthJanitor.Providers.AzureSearch
 {
     [Provider(Name = "Azure Search Admin Key",
               IconClass = "fas fa-search",
-              Description = "Regenerates an Admin Key for an Azure Search service")]
+              Description = "Regenerates an Admin Key for an Azure Search service",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.AZURE_SEARCH_SVG)]
     public class AzureSearchAdminKeyRekeyableObjectProvider : RekeyableObjectProvider<AzureSearchAdminKeyConfiguration>
     {
@@ -21,6 +24,12 @@ namespace AuthJanitor.Providers.AzureSearch
         public AzureSearchAdminKeyRekeyableObjectProvider(ILogger<AzureSearchAdminKeyRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var keys = await (await SearchService).GetAdminKeysAsync();
+            if (keys == null) throw new Exception("Could not get admin keys for Azure Search");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.AzureSql/AzureSqlAdministratorPasswordRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.AzureSql/AzureSqlAdministratorPasswordRekeyableObjectProvider.cs
@@ -13,7 +13,8 @@ namespace AuthJanitor.Providers.AzureSql
 {
     [Provider(Name = "Azure SQL Server Administrator Password",
           IconClass = "fas fa-database",
-          Description = "Regenerates the administrator password of an Azure SQL Server")]
+          Description = "Regenerates the administrator password of an Azure SQL Server",
+          Features = ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.SQL_SERVER_SVG)]
     public class AzureSqlAdministratorPasswordRekeyableObjectProvider : RekeyableObjectProvider<AzureSqlAdministratorPasswordConfiguration>
     {

--- a/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
@@ -11,7 +11,10 @@ namespace AuthJanitor.Providers.CosmosDb
 {
     [Provider(Name = "CosmosDB Master Key",
               IconClass = "fa fa-database",
-              Description = "Regenerates a Master Key for an Azure CosmosDB instance")]
+              Description = "Regenerates a Master Key for an Azure CosmosDB instance",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.COSMOS_DB_SVG)]
     public class CosmosDbRekeyableObjectProvider : RekeyableObjectProvider<CosmosDbKeyConfiguration>
     {
@@ -25,6 +28,12 @@ namespace AuthJanitor.Providers.CosmosDb
         public CosmosDbRekeyableObjectProvider(ILogger<CosmosDbRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var keys = (await CosmosDbAccount).ListKeysAsync();
+            if (keys == null) throw new Exception("Could not access CosmosDB keys");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
@@ -13,7 +13,10 @@ namespace AuthJanitor.Providers.EventHub
 {
     [Provider(Name = "Event Hub Key",
               IconClass = "fa fa-key",
-              Description = "Regenerates an Azure Event Hub Key")]
+              Description = "Regenerates an Azure Event Hub Key",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.EVENT_HUB_SVG)]
     public class EventHubRekeyableObjectProvider : RekeyableObjectProvider<EventHubKeyConfiguration>
     {
@@ -22,6 +25,12 @@ namespace AuthJanitor.Providers.EventHub
         public EventHubRekeyableObjectProvider(ILogger<EventHubRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var keys = await(await GetAuthorizationRule()).GetKeysAsync();
+            if (keys == null) throw new Exception("Could not access Event Hub keys");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.KeyVault/KeyVaultKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.KeyVault/KeyVaultKeyRekeyableObjectProvider.cs
@@ -12,7 +12,10 @@ namespace AuthJanitor.Providers.KeyVault
 {
     [Provider(Name = "Key Vault Key",
               IconClass = "fa fa-key",
-              Description = "Regenerates an Azure Key Vault Key with the same parameters as the previous version")]
+              Description = "Regenerates an Azure Key Vault Key with the same parameters as the previous version",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.KEY_VAULT_SVG)]
     public class KeyVaultKeyRekeyableObjectProvider : RekeyableObjectProvider<KeyVaultKeyConfiguration>
     {
@@ -21,6 +24,12 @@ namespace AuthJanitor.Providers.KeyVault
         public KeyVaultKeyRekeyableObjectProvider(ILogger<KeyVaultKeyRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var key = await GetKeyClient().GetKeyAsync(Configuration.KeyName);
+            if (key == null) throw new Exception("Key was not found or not accessible");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.KeyVault/KeyVaultSecretApplicationLifecycleProvider.cs
+++ b/AuthJanitor.Providers.KeyVault/KeyVaultSecretApplicationLifecycleProvider.cs
@@ -11,7 +11,8 @@ namespace AuthJanitor.Providers.KeyVault
 {
     [Provider(Name = "Key Vault Secret",
               IconClass = "fa fa-low-vision",
-              Description = "Manages the lifecycle of a Key Vault Secret where a Managed Secret's value is stored")]
+              Description = "Manages the lifecycle of a Key Vault Secret where a Managed Secret's value is stored",
+              Features = ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.KEY_VAULT_SVG)]
     public class KeyVaultSecretApplicationLifecycleProvider : ApplicationLifecycleProvider<KeyVaultSecretLifecycleConfiguration>
     {
@@ -20,6 +21,12 @@ namespace AuthJanitor.Providers.KeyVault
         public KeyVaultSecretApplicationLifecycleProvider(ILogger<KeyVaultSecretApplicationLifecycleProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var secret = await GetSecretClient().GetSecretAsync(Configuration.SecretName);
+            if (secret == null) throw new Exception("Could not access Key Vault Secret");
         }
 
         /// <summary>

--- a/AuthJanitor.Providers.KeyVault/KeyVaultSecretRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.KeyVault/KeyVaultSecretRekeyableObjectProvider.cs
@@ -13,7 +13,10 @@ namespace AuthJanitor.Providers.KeyVault
 {
     [Provider(Name = "Key Vault Secret",
               IconClass = "fa fa-low-vision",
-              Description = "Regenerates a Key Vault Secret with a given length")]
+              Description = "Regenerates a Key Vault Secret with a given length",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.KEY_VAULT_SVG)]
     public class KeyVaultSecretRekeyableObjectProvider : RekeyableObjectProvider<KeyVaultSecretConfiguration>
     {
@@ -26,6 +29,12 @@ namespace AuthJanitor.Providers.KeyVault
         {
             _logger = logger;
             _cryptographicImplementation = cryptographicImplementation;
+        }
+
+        public override async Task Test()
+        {
+            var secret = await GetSecretClient().GetSecretAsync(Configuration.SecretName);
+            if (secret == null) throw new Exception("Could not access Key Vault Secret");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
@@ -12,7 +12,10 @@ namespace AuthJanitor.Providers.Redis
 {
     [Provider(Name = "Redis Cache Key",
               IconClass = "fa fa-database",
-              Description = "Regenerates a Master Key for a Redis Cache instance")]
+              Description = "Regenerates a Master Key for a Redis Cache instance",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.REDIS_SVG)]
     public class RedisCacheKeyRekeyableObjectProvider : RekeyableObjectProvider<RedisCacheKeyConfiguration>
     {
@@ -21,6 +24,12 @@ namespace AuthJanitor.Providers.Redis
         public RedisCacheKeyRekeyableObjectProvider(ILogger<RedisCacheKeyRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var keys = (await RedisCache).GetKeys();
+            if (keys == null) throw new Exception("Redis Cache key could not be retrieved");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
@@ -12,7 +12,10 @@ namespace AuthJanitor.Providers.ServiceBus
 {
     [Provider(Name = "Service Bus Key",
               IconClass = "fa fa-key",
-              Description = "Regenerates an Azure Service Bus Key")]
+              Description = "Regenerates an Azure Service Bus Key",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.SERVICE_BUS_SVG)]
     public class ServiceBusRekeyableObjectProvider : RekeyableObjectProvider<ServiceBusKeyConfiguration>
     {
@@ -21,6 +24,12 @@ namespace AuthJanitor.Providers.ServiceBus
         public ServiceBusRekeyableObjectProvider(ILogger<ServiceBusRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var keys = await Get();
+            if (keys == null) throw new Exception("Service Bus key could not be retrieved");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
+++ b/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
@@ -13,7 +13,10 @@ namespace AuthJanitor.Providers.Storage
 {
     [Provider(Name = "Storage Account Key",
               IconClass = "fas fa-file-alt",
-              Description = "Regenerates a key of a specified type for an Azure Storage Account")]
+              Description = "Regenerates a key of a specified type for an Azure Storage Account",
+              Features = ProviderFeatureFlags.CanRotateWithoutDowntime | 
+                         ProviderFeatureFlags.IsTestable |
+                         ProviderFeatureFlags.SupportsSecondaryKey)]
     [ProviderImage(ProviderImages.STORAGE_ACCOUNT_SVG)]
     public class StorageAccountRekeyableObjectProvider : RekeyableObjectProvider<StorageAccountKeyConfiguration>
     {
@@ -27,6 +30,12 @@ namespace AuthJanitor.Providers.Storage
         public StorageAccountRekeyableObjectProvider(ILogger<StorageAccountRekeyableObjectProvider> logger)
         {
             _logger = logger;
+        }
+
+        public override async Task Test()
+        {
+            var key = await Get(KeyName);
+            if (key == null) throw new Exception("Storage Key could not be retrieved");
         }
 
         public override async Task<RegeneratedSecret> GetSecretToUseDuringRekeying()

--- a/AuthJanitor.Providers/ProviderAttribute.cs
+++ b/AuthJanitor.Providers/ProviderAttribute.cs
@@ -4,6 +4,17 @@ using System;
 
 namespace AuthJanitor.Providers
 {
+    [Flags]
+    public enum ProviderFeatureFlags : int
+    {
+        None                        = 0b00000000,
+
+        IsTestable                  = 0b00000010,
+        CanRotateWithoutDowntime    = 0b00000100,
+        SupportsSecondaryKey        = 0b00001000,
+        HasCandidateSelection       = 0b00010000
+    }
+
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class ProviderAttribute : Attribute
     {
@@ -23,9 +34,9 @@ namespace AuthJanitor.Providers
         public string Description { get; set; }
 
         /// <summary>
-        /// URL with more information about the Provider
+        /// Features supported by this Provider
         /// </summary>
-        public string MoreInformationUrl { get; set; }
+        public ProviderFeatureFlags Features { get; set; }
     }
 
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]


### PR DESCRIPTION
Related to #44 

This starts us down the road of feature awareness for Providers. Most of the features given are already present (albeit nothing is functionally aware of these flags right now -- this PR is just for putting them in and displaying them on the Providers page) except for "Candidate Selection". This feature represents a future intent to allow Providers to enumerate possible candidate configurations instead of forcing the user to type it all out. This is especially useful since we already have OBO access from the admin in the intended installation scenario.

I also added some basic tests where there should have been some.