### PR TITLE
Added a data store for entity framework core including unit tests

### DIFF
--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitor.Integrations.DataStores.EntityFrameworkCore.csproj
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitor.Integrations.DataStores.EntityFrameworkCore.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AuthJanitor.AspNet\AuthJanitor.AspNet.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitorDbContext.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitorDbContext.cs
@@ -1,0 +1,31 @@
+﻿using AuthJanitor.UI.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore
+{
+    public class AuthJanitorDbContext : DbContext
+    {
+        public AuthJanitorDbContext()
+        {
+        }
+
+        public AuthJanitorDbContext(DbContextOptions<AuthJanitorDbContext> dbContextOptions) : base(dbContextOptions)
+        {
+        }
+
+        public DbSet<ManagedSecret> ManagedSecrets { get; set; }
+        public DbSet<RekeyingTask> RekeyingTasks { get; set; }
+        public DbSet<Resource> Resources { get; set; }
+        public DbSet<ScheduleWindow> ScheduleWindows { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfigurationsFromAssembly(GetType().Assembly);
+        }
+    }
+}

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitorDbContext.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitorDbContext.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.UI.Shared.Models;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ManagedSecretConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ManagedSecretConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.UI.Shared.Models;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Newtonsoft.Json;

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ManagedSecretConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ManagedSecretConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using AuthJanitor.UI.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore.Configurations
+{
+    public class ManagedSecretConfiguration : IEntityTypeConfiguration<ManagedSecret>
+    {
+        public void Configure(EntityTypeBuilder<ManagedSecret> builder)
+        {
+            builder.HasKey(x => x.ObjectId);
+            // TODO which properties are required?
+            builder.Property(x => x.Name).IsRequired();
+            builder.Property(x => x.AdminEmails)
+                .HasConversion(
+                    v => JsonConvert.SerializeObject(v),
+                    v => JsonConvert.DeserializeObject<List<string>>(v));
+            builder.Property(x => x.ResourceIds)
+                .HasConversion(
+                    v => JsonConvert.SerializeObject(v),
+                    v => JsonConvert.DeserializeObject<List<Guid>>(v));
+            // TODO: We have properties to ignore - are they ignored since they don't have a setter?
+        }
+    }
+}

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/RekeyingTaskConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/RekeyingTaskConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.Providers;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.Providers;
 using AuthJanitor.UI.Shared.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/RekeyingTaskConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/RekeyingTaskConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using AuthJanitor.Providers;
+using AuthJanitor.UI.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore.Configurations
+{
+    public class RekeyingTaskConfiguration : IEntityTypeConfiguration<RekeyingTask>
+    {
+        public void Configure(EntityTypeBuilder<RekeyingTask> builder)
+        {
+            builder.HasKey(x => x.ObjectId);
+            // TODO which properties are required?
+            builder.Property(x => x.Attempts)
+                .HasConversion(
+                    v => JsonConvert.SerializeObject(v),
+                    v => JsonConvert.DeserializeObject<List<RekeyingAttemptLogger>>(v));
+        }
+    }
+}

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ResourceConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ResourceConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.UI.Shared.Models;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ResourceConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ResourceConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using AuthJanitor.UI.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore.Configurations
+{
+    public class ResourceConfiguration : IEntityTypeConfiguration<Resource>
+    {
+        public void Configure(EntityTypeBuilder<Resource> builder)
+        {
+            builder.HasKey(x => x.ObjectId);
+            // TODO which properties are required?
+            builder.Property(x => x.Name).IsRequired();
+            builder.Property(x => x.IsRekeyableObjectProvider).IsRequired();
+            builder.Property(x => x.ProviderType).IsRequired();
+        }
+    }
+}

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ScheduleWindowConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ScheduleWindowConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.UI.Shared.Models;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Newtonsoft.Json;

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ScheduleWindowConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ScheduleWindowConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using AuthJanitor.UI.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore.Configurations
+{
+    public class ScheduleWindowConfiguration : IEntityTypeConfiguration<ScheduleWindow>
+    {
+        public void Configure(EntityTypeBuilder<ScheduleWindow> builder)
+        {
+            builder.HasKey(x => x.ObjectId);
+            builder.Property(x => x.CronStrings).IsRequired();
+            builder.Property(x => x.CronStrings)
+                .HasConversion(
+                    v => JsonConvert.SerializeObject(v),
+                    v => JsonConvert.DeserializeObject<List<string>>(v));
+        }
+    }
+}

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/EntityFrameworkCoreDataStore.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/EntityFrameworkCoreDataStore.cs
@@ -1,0 +1,82 @@
+﻿using AuthJanitor.DataStores;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore
+{
+    public class EntityFrameworkCoreDataStore<TStoredModel> : IDataStore<TStoredModel> where TStoredModel : class, IAuthJanitorModel
+    {
+        private readonly AuthJanitorDbContext dbContext;
+
+        private DbSet<TStoredModel> Set
+        {
+            get
+            {
+                return dbContext.Set<TStoredModel>();
+            }
+        }
+
+        public EntityFrameworkCoreDataStore(AuthJanitorDbContext dbContext)
+        {
+            this.dbContext = dbContext;
+        }
+
+        public async Task<bool> ContainsId(Guid objectId, CancellationToken cancellationToken)
+        {
+            return (await Set.FirstOrDefaultAsync(x => x.ObjectId == objectId, cancellationToken) != default(TStoredModel));
+        }
+
+        public async Task<TStoredModel> Create(TStoredModel model, CancellationToken cancellationToken)
+        {
+            Set.Add(model);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return await Set.FirstOrDefaultAsync(x => x.ObjectId == model.ObjectId, cancellationToken);
+        }
+
+        public async Task Delete(Guid objectId, CancellationToken cancellationToken)
+        {
+            var entity = await Set.FirstOrDefaultAsync(x => x.ObjectId == objectId, cancellationToken);
+            if (entity != null)
+            {
+                Set.Remove(entity);
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        public async Task<ICollection<TStoredModel>> Get(CancellationToken cancellationToken)
+        {
+            return await Set.ToListAsync(cancellationToken);
+        }
+
+        public async Task<ICollection<TStoredModel>> Get(Func<TStoredModel, bool> predicate, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult(Set.Where(predicate).ToList());
+        }
+
+        public Task<TStoredModel> GetOne(Guid objectId, CancellationToken cancellationToken)
+        {
+            return Set.FirstOrDefaultAsync(x => x.ObjectId == objectId, cancellationToken);
+        }
+
+        public Task<TStoredModel> GetOne(Func<TStoredModel, bool> predicate, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Set.Where(predicate).FirstOrDefault());
+        }
+
+        public async Task<TStoredModel> Update(TStoredModel model, CancellationToken cancellationToken)
+        {
+            var entity = await Set.FirstOrDefaultAsync(x => x.ObjectId == model.ObjectId, cancellationToken);
+            if (entity != null)
+            {
+                Set.Remove(entity);
+                Set.Add(model);
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+            return await Set.FirstOrDefaultAsync(x => x.ObjectId == model.ObjectId, cancellationToken);
+        }
+    }
+}

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/EntityFrameworkCoreDataStore.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/EntityFrameworkCoreDataStore.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.DataStores;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.DataStores;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;

--- a/src/AuthJanitor.Tests/AuthJanitor.Tests.csproj
+++ b/src/AuthJanitor.Tests/AuthJanitor.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
@@ -14,7 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AuthJanitor.AspNet\AuthJanitor.AspNet.Core.csproj" />
     <ProjectReference Include="..\AuthJanitor.Integrations.CryptographicImplementations.Default\AuthJanitor.Integrations.CryptographicImplementations.Default.csproj" />
+    <ProjectReference Include="..\AuthJanitor.Integrations.DataStores.EntityFrameworkCore\AuthJanitor.Integrations.DataStores.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\AuthJanitor.Integrations.IdentityServices.AzureActiveDirectory\AuthJanitor.Integrations.IdentityServices.AzureActiveDirectory.csproj" />
   </ItemGroup>
 

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ManagedSecretTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ManagedSecretTests.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.UI.Shared;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared;
 using AuthJanitor.UI.Shared.Models;
 using System;
 

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ManagedSecretTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ManagedSecretTests.cs
@@ -1,0 +1,58 @@
+﻿using AuthJanitor.UI.Shared;
+using AuthJanitor.UI.Shared.Models;
+using System;
+
+namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
+{
+    public class EF_ManagedSecretTests : EF_TestsBase<ManagedSecret>
+    {
+        protected override ManagedSecret CreateModel()
+        {
+            return new ManagedSecret()
+            {
+                ObjectId = Guid.NewGuid(),
+                AdminEmails = new string[] { "admin@admin.com" },
+                Description = "Description",
+                Name = "Name",
+                LastChanged = new DateTimeOffset(DateTime.Now),
+                Nonce = "Nonce",
+                TaskConfirmationStrategies = TaskConfirmationStrategies.AdminCachesSignOff,
+                ValidPeriod = new TimeSpan(24, 0, 0),
+                ResourceIds = new Guid[] { Guid.NewGuid() }
+            };
+        }
+
+        protected override ManagedSecret UpdatedModel()
+        {
+            return new ManagedSecret()
+            {
+                ObjectId = model.ObjectId,
+                AdminEmails = new string[] { "admin@admin.com" },
+                Description = "Another Description",
+                Name = "Another Name",
+                LastChanged = new DateTimeOffset(DateTime.Now),
+                Nonce = "Another Nonce",
+                TaskConfirmationStrategies = TaskConfirmationStrategies.AdminCachesSignOff,
+                ValidPeriod = new TimeSpan(24, 0, 0),
+                ResourceIds = new Guid[] { Guid.NewGuid() }
+            };
+        }
+
+        protected override bool CompareModel(ManagedSecret model1, ManagedSecret model2)
+        {
+            if (model1.ObjectId != model2.ObjectId ||
+                model1.Description != model2.Description ||
+                model1.Name != model2.Name ||
+                model1.LastChanged != model2.LastChanged ||
+                model1.Nonce != model2.Nonce ||
+                model1.TaskConfirmationStrategies != model2.TaskConfirmationStrategies ||
+                model1.ValidPeriod != model2.ValidPeriod)
+                return false;
+            if (!model1.AdminEmails.Equals(model2.AdminEmails))
+                return false;
+            if (!model1.ResourceIds.Equals(model2.ResourceIds))
+                return false;
+            return true;
+        }
+    }
+}

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_RekeyingTaskTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_RekeyingTaskTests.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.Providers;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.Providers;
 using AuthJanitor.UI.Shared;
 using AuthJanitor.UI.Shared.Models;
 using System;

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_RekeyingTaskTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_RekeyingTaskTests.cs
@@ -1,0 +1,93 @@
+﻿using AuthJanitor.Providers;
+using AuthJanitor.UI.Shared;
+using AuthJanitor.UI.Shared.Models;
+using System;
+using System.Collections.Generic;
+
+namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
+{
+    public class EF_RekeyingTaskTests : EF_TestsBase<RekeyingTask>
+    {
+        protected override RekeyingTask CreateModel()
+        {
+            return new RekeyingTask()
+            {
+                ObjectId = Guid.NewGuid(),
+                AvailabilityScheduleId = Guid.NewGuid(),
+                Attempts = new List<RekeyingAttemptLogger>()
+                {
+                    new RekeyingAttemptLogger()
+                    {
+                        AttemptStarted = new DateTimeOffset(DateTime.Now),
+                        AttemptFinished = new DateTimeOffset(DateTime.Now),
+                        ChainedLogger = null,
+                        LogString = "LogString",
+                        OuterException = "OuterException",
+                        UserDisplayName = "UserName",
+                        UserEmail = "user@email.com"
+                    }
+                },
+                ConfirmationType = TaskConfirmationStrategies.AdminCachesSignOff,
+                Expiry = new DateTimeOffset(DateTime.Now),
+                ManagedSecretId = Guid.NewGuid(),
+                PersistedCredentialId = Guid.NewGuid(),
+                PersistedCredentialUser = "CredentialUser",
+                RekeyingInProgress = false,
+                Queued = new DateTimeOffset(DateTime.Now),
+                RekeyingCompleted = false,
+                RekeyingFailed = true
+            };
+        }
+
+        protected override RekeyingTask UpdatedModel()
+        {
+            return new RekeyingTask()
+            {
+                ObjectId = model.ObjectId,
+                AvailabilityScheduleId = Guid.NewGuid(),
+                Attempts = new List<RekeyingAttemptLogger>()
+                {
+                    new RekeyingAttemptLogger()
+                    {
+                        AttemptStarted = new DateTimeOffset(DateTime.Now),
+                        AttemptFinished = new DateTimeOffset(DateTime.Now),
+                        ChainedLogger = null,
+                        LogString = "Another LogString",
+                        OuterException = "Another OuterException",
+                        UserDisplayName = "Another UserName",
+                        UserEmail = "user2@email.com"
+                    }
+                },
+                ConfirmationType = TaskConfirmationStrategies.AdminCachesSignOff,
+                Expiry = new DateTimeOffset(DateTime.Now),
+                ManagedSecretId = Guid.NewGuid(),
+                PersistedCredentialId = Guid.NewGuid(),
+                PersistedCredentialUser = "Another CredentialUser",
+                RekeyingInProgress = false,
+                Queued = new DateTimeOffset(DateTime.Now),
+                RekeyingCompleted = false,
+                RekeyingFailed = true
+            };
+        }
+
+        protected override bool CompareModel(RekeyingTask model1, RekeyingTask model2)
+        {
+            if (model1.ObjectId != model2.ObjectId ||
+                    model1.AvailabilityScheduleId != model2.AvailabilityScheduleId ||
+                    model1.Attempts != model2.Attempts ||
+                    model1.ConfirmationType != model2.ConfirmationType ||
+                    model1.Expiry != model2.Expiry ||
+                    model1.ManagedSecretId != model2.ManagedSecretId ||
+                    model1.PersistedCredentialId != model2.PersistedCredentialId ||
+                    model1.PersistedCredentialUser != model2.PersistedCredentialUser ||
+                    model1.RekeyingInProgress != model2.RekeyingInProgress ||
+                    model1.Queued != model2.Queued ||
+                    model1.RekeyingCompleted != model2.RekeyingCompleted ||
+                    model1.RekeyingFailed != model2.RekeyingFailed)
+                return false;
+            if (!model1.Attempts.Equals(model2.Attempts))
+                return false;
+            return true;
+        }
+    }
+}

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ResourceTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ResourceTests.cs
@@ -1,0 +1,46 @@
+﻿using AuthJanitor.UI.Shared.Models;
+using System;
+
+namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
+{
+    public class EF_ResourceTests : EF_TestsBase<Resource>
+    {
+        protected override Resource CreateModel()
+        {
+            return new Resource()
+            {
+                ObjectId = Guid.NewGuid(),
+                Description = "Description",
+                IsRekeyableObjectProvider = true,
+                Name = "Name",
+                ProviderConfiguration = "ProviderConfiguration",
+                ProviderType = "ProviderType"
+            };
+        }
+
+        protected override Resource UpdatedModel()
+        {
+            return new Resource()
+            {
+                ObjectId = model.ObjectId,
+                Description = "Another Description",
+                IsRekeyableObjectProvider = false,
+                Name = "Another Name",
+                ProviderConfiguration = "Another ProviderConfiguration",
+                ProviderType = "Another ProviderType"
+            };
+        }
+
+        protected override bool CompareModel(Resource model1, Resource model2)
+        {
+            if (model1.ObjectId != model2.ObjectId ||
+                model1.Description != model2.Description ||
+                model1.IsRekeyableObjectProvider != model2.IsRekeyableObjectProvider ||
+                model1.Name != model2.Name ||
+                model1.ProviderConfiguration != model2.ProviderConfiguration ||
+                model1.ProviderType != model2.ProviderType)
+                return false;
+            return true;
+        }
+    }
+}

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ResourceTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ResourceTests.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.UI.Shared.Models;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared.Models;
 using System;
 
 namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ScheduleWindowTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ScheduleWindowTests.cs
@@ -1,0 +1,38 @@
+﻿using AuthJanitor.UI.Shared.Models;
+using System;
+using System.Linq;
+
+namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
+{
+    public class EF_ScheduleWindowTests : EF_TestsBase<ScheduleWindow>
+    {
+        protected override ScheduleWindow CreateModel()
+        {
+            return new ScheduleWindow()
+            {
+                ObjectId = Guid.NewGuid(),
+                CronStrings = new string[] { "TODO" }
+            };
+        }
+
+        protected override ScheduleWindow UpdatedModel()
+        {
+            return new ScheduleWindow()
+            {
+                ObjectId = model.ObjectId,
+                CronStrings = new string[] { "TODO2" }
+            };
+        }
+
+        protected override bool CompareModel(ScheduleWindow model1, ScheduleWindow model2)
+        {
+            if (model1.ObjectId != model2.ObjectId)
+                return false;
+            if (model1.CronStrings.Count() != model2.CronStrings.Count())
+                return false;
+            if (!model1.CronStrings.Equals(model2.CronStrings))
+                return false;
+            return true;
+        }
+    }
+}

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ScheduleWindowTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ScheduleWindowTests.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.UI.Shared.Models;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared.Models;
 using System;
 using System.Linq;
 

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_TestsBase.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_TestsBase.cs
@@ -1,4 +1,6 @@
-﻿using AuthJanitor.DataStores;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.DataStores;
 using AuthJanitor.Integrations.DataStores.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using System;

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_TestsBase.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_TestsBase.cs
@@ -1,0 +1,143 @@
+﻿using AuthJanitor.DataStores;
+using AuthJanitor.Integrations.DataStores.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
+{
+    public abstract class EF_TestsBase<TStoredModel> where TStoredModel : class, IAuthJanitorModel
+    {
+        private AuthJanitorDbContext dbContext = null;
+        protected TStoredModel model = null;
+
+        protected EntityFrameworkCoreDataStore<TStoredModel> GetDataStore()
+        {
+            if (model == null)
+                model = CreateModel();
+            if (dbContext == null)
+                dbContext = new AuthJanitorDbContext(new DbContextOptionsBuilder<AuthJanitorDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+            return new EntityFrameworkCoreDataStore<TStoredModel>(dbContext);
+        }
+
+        protected Task CleanModel()
+        {
+            dbContext.Set<TStoredModel>().RemoveRange(dbContext.Set<TStoredModel>().ToArray());
+            return dbContext.SaveChangesAsync();
+        }
+
+        protected abstract TStoredModel CreateModel();
+        protected abstract TStoredModel UpdatedModel();
+        protected abstract bool CompareModel(TStoredModel model1, TStoredModel model2);
+
+        [Fact]
+        public async Task ValidatesCreate()
+        {
+            var datastore = GetDataStore();
+            var storedModel = await datastore.Create(model, CancellationToken.None);
+            Assert.True(CompareModel(model, storedModel));
+            var fetchedModel = await datastore.GetOne(model.ObjectId, CancellationToken.None);
+            Assert.True(CompareModel(model, fetchedModel));
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesUpdate()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var updatedModel = UpdatedModel();
+            var storedModel = await datastore.Update(updatedModel, CancellationToken.None);
+            Assert.True(CompareModel(updatedModel, storedModel));
+            var fetchedModel = await datastore.GetOne(model.ObjectId, CancellationToken.None);
+            Assert.True(CompareModel(updatedModel, fetchedModel));
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesGet()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var models = await datastore.Get(CancellationToken.None);
+            Assert.Equal(1, models.Count);
+            Assert.True(CompareModel(model, models.First()));
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesGetWithPredicateReturnsModelResult()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var models = await datastore.Get(x => x.ObjectId == model.ObjectId, CancellationToken.None);
+            Assert.Equal(1, models.Count);
+            Assert.True(CompareModel(model, models.First()));
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesGetWithPredicateReturnsNoResult()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var models = await datastore.Get(x => x.ObjectId == Guid.NewGuid(), CancellationToken.None);
+            Assert.Equal(0, models.Count);
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesGetOne()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var modelOne = await datastore.GetOne(model.ObjectId, CancellationToken.None);
+            Assert.True(CompareModel(model, modelOne));
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesGetOneWithPredicateReturnsModelResult()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var modelOne = await datastore.GetOne(x => x.ObjectId == model.ObjectId, CancellationToken.None);
+            Assert.True(CompareModel(model, modelOne));
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesGetOneWithPredicateReturnsNoResult()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var modelOne = await datastore.GetOne(x => x.ObjectId == Guid.NewGuid(), CancellationToken.None);
+            Assert.Null(modelOne);
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesContainsId()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            var exists = await datastore.ContainsId(model.ObjectId, CancellationToken.None);
+            Assert.True(exists);
+            await CleanModel();
+        }
+
+        [Fact]
+        public async Task ValidatesDelete()
+        {
+            var datastore = GetDataStore();
+            await datastore.Create(model, CancellationToken.None);
+            await datastore.Delete(model.ObjectId, CancellationToken.None);
+            var models = await datastore.Get(CancellationToken.None);
+            Assert.Equal(0, models.Count);
+            await CleanModel();
+        }
+    }
+}

--- a/src/AuthJanitor.sln
+++ b/src/AuthJanitor.sln
@@ -67,6 +67,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthJanitor.Providers.Azure
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthJanitor.Tests", "AuthJanitor.Tests\AuthJanitor.Tests.csproj", "{4EF08D3E-5F88-4156-8BBA-9FD8A3065190}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthJanitor.Integrations.DataStores.EntityFrameworkCore", "AuthJanitor.Integrations.DataStores.EntityFrameworkCore\AuthJanitor.Integrations.DataStores.EntityFrameworkCore.csproj", "{BCEC6AD5-4A69-4440-8643-AED247F45281}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -169,6 +171,10 @@ Global
 		{4EF08D3E-5F88-4156-8BBA-9FD8A3065190}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4EF08D3E-5F88-4156-8BBA-9FD8A3065190}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4EF08D3E-5F88-4156-8BBA-9FD8A3065190}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCEC6AD5-4A69-4440-8643-AED247F45281}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCEC6AD5-4A69-4440-8643-AED247F45281}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCEC6AD5-4A69-4440-8643-AED247F45281}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCEC6AD5-4A69-4440-8643-AED247F45281}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -199,6 +205,7 @@ Global
 		{AF18A358-231F-4D8E-A659-AEB660CC4715} = {93A3274C-6CD8-4399-9C45-7D0A4077E4E0}
 		{93A3274C-6CD8-4399-9C45-7D0A4077E4E0} = {9C0E454F-146E-40FB-AFE5-F63DAACAB326}
 		{7EDE5077-75D1-4D60-85AA-94E1F99525EC} = {93A3274C-6CD8-4399-9C45-7D0A4077E4E0}
+		{BCEC6AD5-4A69-4440-8643-AED247F45281} = {07EE807A-D975-4B1D-B486-6633ED87B757}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0461C5FC-1885-4C0F-B202-817D99C927D2}


### PR DESCRIPTION
This is the first attempt at writing a data store for Entity Framework Code. Here we have intentionally left the data model as is - that is we don't have a secondary normalized data model that we store. This is up for discussion. This is the implementation if #78 .