### PR TITLE
Fix inline help slide-in

### DIFF
--- a/src/AuthJanitor.AspNet.AdminUi/Shared/MainLayout.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Shared/MainLayout.razor
@@ -99,17 +99,10 @@
 @code
 { protected DashboardMetricsViewModel Metrics { get; set; } = new DashboardMetricsViewModel();
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await JSRuntime.InvokeVoidAsync("InitializeHelpSlideIn");
-        }
-    }
-
     protected override async Task OnInitializedAsync()
     {
         Metrics = await Http.AJGet<DashboardMetricsViewModel>();
+        await JSRuntime.InvokeVoidAsync("InitializeHelpSlideIn");
     }
 
     protected string GetGravatar()


### PR DESCRIPTION
This was previously double-bound by the OnAfterRenderAsync in certain scenarios, which meant toggle-in and toggle-out were being called simultaneously. This is a quick fix. :)