### PR TITLE
Provider SVGs, inline help as Blazor syntax

### DIFF
--- a/src/AuthJanitor.AspNet.AdminUi/Components/HelpSlideInComponent.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Components/HelpSlideInComponent.razor
@@ -1,4 +1,4 @@
-﻿<div id="helpContainer" class="help-container text-light border-right-0 border-info rounded-left shadow-lg">
+﻿<div id="helpContainer" class="help-container text-light border-right-0 border-info rounded-left shadow-lg @(Visible ? "in" : "")">
     <h1 class="display-4">
         <i class="@Icon mr-2"></i>
         @Title
@@ -12,6 +12,12 @@
 
     [Parameter]
     public string Icon { get; set; }
+
+    [Parameter]
+    public bool Visible { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> VisibleChanged { get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/src/AuthJanitor.AspNet.AdminUi/Components/SystemWideFooter.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Components/SystemWideFooter.razor
@@ -5,7 +5,7 @@
             <div class="col px-3 my-auto text-left text-muted small">Powered by <a href="https://www.authjanitor.com" class="text-muted" target="_blank">AuthJanitor</a></div>
             <div class="col px-1 text-right">
                 <div class="float-right pt-1 px-2 border-left">
-                    <a href="javascript:false;" data-toggle="toggle" role="button" data-target="#helpContainer" class="text-decoration-none px-1">
+                    <a href="" @onclick="@(() => ChangeContextualHelpVisibility())" @onclick:preventDefault title="Contextual Help" class="text-decoration-none px-1">
                         <i class="fa fa-question-circle text-info"></i>
                     </a>
                     <a href="https://github.com/microsoft/AuthJanitor" target="_blank" class="text-decoration-none px-1">
@@ -23,16 +23,16 @@
                 <div class="float-right mr-2">
                     @if (Metrics.TasksInError > 0)
                     {
-        <a class="btn btn-sm btn-outline-danger mx-2" role="button" href="/rekeyingTasks">
-            Errors <span class="badge badge-danger">@Metrics.TasksInError</span>
-            <span class="sr-only">in rekeying tasks</span>
-        </a>}
+                        <a class="btn btn-sm btn-outline-danger mx-2" role="button" href="/rekeyingTasks">
+                            Errors <span class="badge badge-danger">@Metrics.TasksInError</span>
+                            <span class="sr-only">in rekeying tasks</span>
+                        </a>}
                     @if (Metrics.TotalPendingApproval > 0)
                     {
-        <a class="btn btn-sm btn-outline-success mx-2" role="button" href="/rekeyingTasks">
-            Approvals <span class="badge badge-success">@Metrics.TotalPendingApproval</span>
-            <span class="sr-only">for pending rekeying tasks</span>
-        </a>}
+                        <a class="btn btn-sm btn-outline-success mx-2" role="button" href="/rekeyingTasks">
+                            Approvals <span class="badge badge-success">@Metrics.TotalPendingApproval</span>
+                            <span class="sr-only">for pending rekeying tasks</span>
+                        </a>}
                 </div>
             </div>
         </div>
@@ -45,6 +45,18 @@
 
     [Parameter]
     public EventCallback RefreshDataClicked { get; set; }
+
+    [Parameter]
+    public bool ContextualHelpVisible { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ContextualHelpVisibleChanged { get; set; }
+
+    protected void ChangeContextualHelpVisibility()
+    {
+        ContextualHelpVisible = !ContextualHelpVisible;
+        ContextualHelpVisibleChanged.InvokeAsync(ContextualHelpVisible);
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/AuthJanitor.AspNet.AdminUi/Editors/ManagedSecretEditor.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Editors/ManagedSecretEditor.razor
@@ -2,11 +2,10 @@
     @foreach (var item in Resources.OrderBy(r => r.Name))
     {
         <Row>
-            <Column ColumnSize="ColumnSize.IsAuto">
-                @{ var color = item.IsRekeyableObjectProvider ? "text-primary" : "text-secondary"; } 
-                <i class="@item.ProviderDetail.IconClass @color"></i>
+            <Column ColumnSize="ColumnSize.Is2" >
+                @((MarkupString)item.Provider.SvgImage)
             </Column>
-            <Column>
+            <Column ColumnSize="ColumnSize.Is10">
                 <Check TValue="bool" CheckedChanged="@(v => UpdateObject(item.ObjectId, v))"><strong>@item.Name</strong></Check>
                 <small>@item.Description</small>
             </Column>

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/AccessManagement.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/AccessManagement.razor
@@ -66,7 +66,8 @@
     </Row>
 
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Access Management"
-                                                    Icon="@FontAwesomeIcons.UserCheck">
+                                                    Icon="@FontAwesomeIcons.UserCheck"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <Paragraph>
             The <strong>Access Management</strong> tool allows administrators with management access to the identity service being
             leveraged to add, remove, and list users who have access to the AuthJanitor tool at various permissions levels.
@@ -94,7 +95,8 @@
                          ObjectName="@($"{SelectedValue.DisplayName} ({SelectedValue.UPN})")"
                          ResultClicked="@DeleteUserConfirmCallback" />
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible" />
 
 @using Newtonsoft.Json
 @code {
@@ -103,6 +105,7 @@
     protected bool CreateModalShowing { get; set; }
     protected bool DeleteRoleModalShowing { get; set; }
     protected bool DeleteUserModalShowing { get; set; }
+    protected bool ContextualHelpVisible { get; set; }
 
     [Parameter]
     public AuthJanitorAuthorizedUserViewModel SelectedValue { get; set; } = new AuthJanitorAuthorizedUserViewModel();
@@ -110,7 +113,7 @@
     [Parameter]
     public EventCallback<AuthJanitorAuthorizedUserViewModel> SelectedValueChanged { get; set; }
 
-    protected override Task OnInitializedAsync() => LoadData();
+    protected override async Task OnInitializedAsync() => await LoadData();
 
     protected async Task LoadData()
     {

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/Dashboard.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/Dashboard.razor
@@ -64,15 +64,19 @@ else
 </Row>}
 
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Dashboard"
-                                                    Icon="@FontAwesomeIcons.TachometerAlt">
+                                                    Icon="@FontAwesomeIcons.TachometerAlt"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <p>The AuthJanitor Dashboard shows a brief look at the most important parts of your key and secret management system.</p>
     </AuthJanitor.UI.Components.HelpSlideInComponent>
 </Container>
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible" />
 
 @using AuthJanitor.UI.Shared.ViewModels
 @code { protected DashboardMetricsViewModel Metrics { get; set; } = new DashboardMetricsViewModel();
+    
+    protected bool ContextualHelpVisible { get; set; }
 
     protected override async Task OnInitializedAsync() => await LoadData();
 

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/IntegrityReports.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/IntegrityReports.razor
@@ -111,7 +111,8 @@
     </Row>
 
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Integrity Reports"
-                                                    Icon="@FontAwesomeIcons.ClipboardCheck">
+                                                    Icon="@FontAwesomeIcons.ClipboardCheck"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <p>
             Since AuthJanitor runs your key/secret management infrastructure, it's important to know that AuthJanitor itself is
             secure. In order to accomplish this, several metrics are collected about all of the libraries loaded into the
@@ -126,11 +127,13 @@
     </AuthJanitor.UI.Components.HelpSlideInComponent>
 </Container>
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())" 
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
 @using AuthJanitor.Integrity
 @code {
     protected IEnumerable<IntegrityReport> IntegrityReportList { get; set; } = new List<IntegrityReport>();
+    protected bool ContextualHelpVisible { get; set; }
 
     protected override async Task OnInitializedAsync() => await LoadData();
 

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/ManagedSecretDetail.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/ManagedSecretDetail.razor
@@ -19,10 +19,11 @@
                 Services Affected
             </Heading>
         </Column>
-        <Column ColumnSize="ColumnSize.Is6.Is9.OnWidescreen" Padding="Padding.Is2" Class="border-left text-danger">
-            <Icon Name="FontAwesomeIcons.Globe" Padding="Padding.Is1" />
-            <Icon Name="FontAwesomeIcons.Globe" Padding="Padding.Is1" />
-            <Icon Name="FontAwesomeIcons.Globe" Padding="Padding.Is1" />
+        <Column ColumnSize="ColumnSize.Is6.Is9.OnWidescreen" Padding="Padding.Is2" Class="border-left">
+            @foreach (var item in this.Secret.Resources)
+            {
+            <div style="width:1em;" class="mr-3 float-left" title="@item.Name">@((MarkupString)item.Provider.SvgImage)</div>
+            }
         </Column>
     </Row>
 
@@ -78,8 +79,8 @@
                 <Card>
                     <CardBody>
                         <Row>
-                            <Column ColumnSize="ColumnSize.Is3">
-                                SVG
+                            <Column ColumnSize="ColumnSize.Is3" Class="providerImage">
+                                @((MarkupString)resource.Provider.SvgImage)
                             </Column>
                             <Column ColumnSize="ColumnSize.Is9">
                                 <Heading Size="HeadingSize.Is3">
@@ -117,7 +118,8 @@
         }
     </Row>
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Secrets"
-                                                    Icon="@FontAwesomeIcons.Key">
+                                                    Icon="@FontAwesomeIcons.Key"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <Paragraph>
             <strong>Secrets</strong> are the combination of multiple <strong>Resources</strong> which work together to provide
             services to an application. A <strong>Secret</strong> typically consists of at least one Rekeyable Object Provider
@@ -133,10 +135,12 @@
     </AuthJanitor.UI.Components.HelpSlideInComponent>
 </Container>
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())" 
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
 @code {
     public ManagedSecretViewModel Secret { get; set; } = new ManagedSecretViewModel();
+    protected bool ContextualHelpVisible { get; set; }
 
     [Parameter]
     public string SecretId { get; set; }
@@ -144,7 +148,7 @@
     public TimeSpan DurationSoFar => DateTimeOffset.UtcNow - Secret.LastChanged.GetValueOrDefault();
     protected IEnumerable<LoadedProviderViewModel> _providers;
 
-    protected override async Task OnInitializedAsync() => LoadData();
+    protected override async Task OnInitializedAsync() => await LoadData();
 
     protected async Task LoadData()
     {

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/ManagedSecrets.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/ManagedSecrets.razor
@@ -67,9 +67,13 @@
                         <ListGroup Margin="Margin.Is0.OnAll" Padding="Padding.Is0.OnAll">
                             @foreach (var resource in context.Resources)
                             {
-<ListGroupItem Padding="Padding.Is1.OnAll">
-    @resource.Name
-</ListGroupItem>}
+                            <ListGroupItem Padding="Padding.Is1.OnAll" Class="justify-content-between align-items-center d-flex">
+                                <div>
+                                    <div style="width:1em;" class="mr-2 float-left">@((MarkupString)resource.Provider.SvgImage)</div>
+                                    @resource.Name
+                                </div>
+                                <ColoredRiskScore ShowRiskText="false" Value="@resource.RiskScore" />
+                            </ListGroupItem>}
                         </ListGroup>
                     </Template>
                 </BlazorTable.Column>
@@ -80,7 +84,8 @@
         </Column>
     </Row>
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Secrets"
-                                                    Icon="@FontAwesomeIcons.Key">
+                                                    Icon="@FontAwesomeIcons.Key"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <p>
             <strong>Secrets</strong> are the combination of multiple <strong>Resources</strong> which work together to provide
             services to an application. A <strong>Secret</strong> typically consists of at least one Rekeyable Object Provider
@@ -108,53 +113,58 @@
                          ObjectName="@SelectedValue.Name"
                          ResultClicked="@DeleteConfirmCallback" />
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
-@code { protected IEnumerable<ManagedSecretViewModel> Secrets { get; set; } = new List<ManagedSecretViewModel>();
+@code
+{ 
+    protected IEnumerable<ManagedSecretViewModel> Secrets { get; set; } = new List<ManagedSecretViewModel>();
 
-            protected bool CreateModalShowing { get; set; }
-            protected bool DeleteModalShowing { get; set; }
+    protected bool CreateModalShowing { get; set; }
+    protected bool DeleteModalShowing { get; set; }
+    protected bool ContextualHelpVisible { get; set; }
 
-            [Parameter]
-            public ManagedSecretViewModel SelectedValue { get; set; } = new ManagedSecretViewModel();
+    [Parameter]
+    public ManagedSecretViewModel SelectedValue { get; set; } = new ManagedSecretViewModel();
 
-            [Parameter]
-            public EventCallback<ManagedSecretViewModel> SelectedValueChanged { get; set; }
+    [Parameter]
+    public EventCallback<ManagedSecretViewModel> SelectedValueChanged { get; set; }
 
-            protected override Task OnInitializedAsync() => LoadData();
+    protected override async Task OnInitializedAsync() => await LoadData();
 
-            protected async Task LoadData()
-            {
-                Secrets = await Http.AJList<ManagedSecretViewModel>();
-                await Task.WhenAll(Secrets.SelectMany(s => s.Resources).Distinct().Select(async resource =>
-                {
-                    resource.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(resource.ProviderType);
-                    resource.ProviderConfiguration.SerializedConfiguration = resource.SerializedProviderConfiguration;
-                }));
-            }
+    protected async Task LoadData()
+    {
+        Secrets = await Http.AJList<ManagedSecretViewModel>();
+        await Task.WhenAll(Secrets.SelectMany(s => s.Resources).Distinct().Select(async resource =>
+        {
+            resource.ProviderConfiguration = await Http.AJGet<ProviderConfigurationViewModel>(resource.ProviderType);
+            resource.ProviderConfiguration.SerializedConfiguration = resource.SerializedProviderConfiguration;
+        }));
+    }
 
-            protected void CreateNew()
-            {
-                SelectedValue = new ManagedSecretViewModel();
-                CreateModalShowing = true;
-            }
+    protected void CreateNew()
+    {
+        SelectedValue = new ManagedSecretViewModel();
+        CreateModalShowing = true;
+    }
 
-            protected async Task CreateCallback(bool result)
-            {
-                if (result)
-                {
-                    await Http.AJCreate<ManagedSecretViewModel>(SelectedValue);
-                    await LoadData();
-                }
-                CreateModalShowing = false;
-            }
+    protected async Task CreateCallback(bool result)
+    {
+        if (result)
+        {
+            await Http.AJCreate<ManagedSecretViewModel>(SelectedValue);
+            await LoadData();
+        }
+        CreateModalShowing = false;
+    }
 
-            protected async Task DeleteConfirmCallback(bool result)
-            {
-                if (result)
-                {
-                    await Http.AJDelete<ManagedSecretViewModel>(SelectedValue.ObjectId);
-                    await LoadData();
-                }
-                DeleteModalShowing = false;
-            } }
+    protected async Task DeleteConfirmCallback(bool result)
+    {
+        if (result)
+        {
+            await Http.AJDelete<ManagedSecretViewModel>(SelectedValue.ObjectId);
+            await LoadData();
+        }
+        DeleteModalShowing = false;
+    }
+}

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/Providers.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/Providers.razor
@@ -58,7 +58,8 @@
     </Row>
 
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Providers"
-                                                    Icon="@FontAwesomeIcons.Plug">
+                                                    Icon="@FontAwesomeIcons.Plug"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <Paragraph>
             A <strong>Provider</strong> is a software library for AuthJanitor which implements the logic necessary to either rekey
             a service or object, or consume a secret or key to facilitate the operation of an application.
@@ -69,11 +70,13 @@
     </AuthJanitor.UI.Components.HelpSlideInComponent>
 </Container>
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
 @using AuthJanitor.UI.Shared.ViewModels;
 @code {
     protected IEnumerable<LoadedProviderViewModel> ProviderList { get; set; } = new List<LoadedProviderViewModel>();
+    protected bool ContextualHelpVisible { get; set; }
 
     protected override async Task OnInitializedAsync() => await LoadData();
 

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/RekeyingTaskDetail.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/RekeyingTaskDetail.razor
@@ -127,7 +127,8 @@
         }
 
         <AuthJanitor.UI.Components.HelpSlideInComponent Title="Rekeying Tasks"
-                                                        Icon="@FontAwesomeIcons.Tasks">
+                                                        Icon="@FontAwesomeIcons.Tasks"
+                                                        @bind-Visible="@ContextualHelpVisible">
             <Paragraph>
                 <strong>Rekeying Tasks</strong> are created, either automatically by the system as a key or secret nears its expiry,
                 or manually by an administrator. A <strong>Rekeying Task</strong> is associated with a <em>single</em>
@@ -137,12 +138,15 @@
         </AuthJanitor.UI.Components.HelpSlideInComponent>
 </Container>
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
 @using AuthJanitor.UI.Shared.ViewModels
 @code {
     public ManagedSecretViewModel Secret => Task == null ? new ManagedSecretViewModel() : Task.ManagedSecret;
     public RekeyingTaskViewModel Task { get; set; } = new RekeyingTaskViewModel();
+
+    protected bool ContextualHelpVisible { get; set; }
 
     [Parameter]
     public string RekeyingTaskId { get; set; }

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/RekeyingTasks.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/RekeyingTasks.razor
@@ -52,7 +52,7 @@
                         else if (!string.IsNullOrEmpty(context.RekeyingErrorMessage))
                         {
                             var attempt = context.Attempts.OrderByDescending(a => a.AttemptStarted).First();
-                            <Alert Color="Color.Danger" IsDismisable="false" IsShow="true">
+                            <Alert Color="Color.Danger" Dismisable="false" Visible="true">
                                 <strong>Error Rekeying!</strong> (Last attempted @attempt.AttemptStarted by @attempt.UserDisplayName)
                             </Alert>
                         }
@@ -70,13 +70,16 @@
                 <!-- Participating Resources -->
                 <BlazorTable.Column TableItem="RekeyingTaskViewModel" Title="Resources">
                     <Template>
-                        <ListGroup Margin="Margin.Is0.OnX.Is1.OnY" Padding="Padding.Is0.OnAll">
+                        <ListGroup Margin="Margin.Is0.OnAll" Padding="Padding.Is0.OnAll">
                             @foreach (var resource in context.ManagedSecret.Resources)
                             {
-                                <ListGroupItem Padding="Padding.Is1.OnAll">
-                                    @resource.Name
-                                </ListGroupItem>
-                            }
+                                <ListGroupItem Padding="Padding.Is1.OnAll" Class="justify-content-between align-items-center d-flex">
+                                    <div>
+                                        <div style="width:1em;" class="mr-2 float-left">@((MarkupString)resource.Provider.SvgImage)</div>
+                                        @resource.Name
+                                    </div>
+                                    <ColoredRiskScore ShowRiskText="false" Value="@resource.RiskScore" />
+                                </ListGroupItem>}
                         </ListGroup>
                     </Template>
                 </BlazorTable.Column>
@@ -88,7 +91,8 @@
     </Row>
 
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Rekeying Tasks"
-                                                    Icon="@FontAwesomeIcons.Tasks">
+                                                    Icon="@FontAwesomeIcons.Tasks"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <Paragraph>
             <strong>Rekeying Tasks</strong> are created, either automatically by the system as a key or secret nears its expiry,
             or manually by an administrator. A <strong>Rekeying Task</strong> is associated with a <em>single</em>
@@ -110,7 +114,8 @@
                          ObjectName="@SelectedValue.ObjectId.ToString()"
                          ResultClicked="@DeleteConfirmCallback" />
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
 @using AuthJanitor.UI.Modals
 @using AuthJanitor.UI.Shared.ViewModels
@@ -119,6 +124,7 @@
 
     protected bool ApproveModalShowing { get; set; }
     protected bool DeleteModalShowing { get; set; }
+    protected bool ContextualHelpVisible { get; set; }
 
     [Parameter]
     public RekeyingTaskViewModel SelectedValue { get; set; } = new RekeyingTaskViewModel();
@@ -126,7 +132,7 @@
     [Parameter]
     public EventCallback<RekeyingTaskViewModel> SelectedValueChanged { get; set; }
 
-    protected override Task OnInitializedAsync() => LoadData();
+    protected override async Task OnInitializedAsync() => await LoadData();
 
     protected async Task LoadData() => Tasks = await Http.AJList<RekeyingTaskViewModel>();
 

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/ResourceDetail.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/ResourceDetail.razor
@@ -7,7 +7,14 @@
                                              OptionalObjectName="@Resource.Name" />
 
     <Row Class="border-bottom">
-        <Column Padding="Padding.Is3" Class="bg-light">
+        @if (_provider != null)
+        {
+        <Column Class="bg-light" Margin="Margin.IsAuto.OnY" ColumnSize="ColumnSize.Is1">
+            <div class="providerImage my-2 mx-auto">@((MarkupString)_provider.SvgImage)</div>
+            <div class="d-none d-sm-block text-center border-top py-2 small">@_provider.Details.Name</div>
+        </Column>
+        }
+        <Column Padding="Padding.Is3" Class="bg-light" ColumnSize="ColumnSize.Is11">
             <DisplayHeading Size="DisplayHeadingSize.Is4">@Resource.Name</DisplayHeading>
             <Paragraph Margin="Margin.Is2.OnY" Class="lead">@Resource.Description</Paragraph>
         </Column>
@@ -82,7 +89,8 @@
     </Row>
 
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Resources"
-                                                    Icon="@FontAwesomeIcons.Database">
+                                                    Icon="@FontAwesomeIcons.Database"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <Paragraph>
             <strong>Resources</strong> describe the configuration required to access a given service or object for the purposes
             of either delivering key/secret material or rekeying that object or service. A <strong>Resource</strong> is made up
@@ -93,12 +101,15 @@
 
 </Container>
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
 @using AuthJanitor.UI.Shared.ViewModels
 @code {
     [Parameter]
     public string ResourceId { get; set; }
+
+    protected bool ContextualHelpVisible { get; set; }
 
     public ResourceViewModel Resource { get; set; } = new ResourceViewModel();
     protected LoadedProviderViewModel _provider;

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/Resources.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/Resources.razor
@@ -48,7 +48,7 @@
 
                 <!-- Provider -->
                 <BlazorTable.Column TableItem="AuthJanitor.UI.Shared.ViewModels.ResourceViewModel"
-                                    Title="Provider" Field="@(x => x.ProviderDetail.Name)"
+                                    Title="Provider" Field="@(x => x.Provider.Details.Name)"
                                     Sortable="true" Filterable="true" />
 
                 <!-- Risk Score -->
@@ -68,7 +68,8 @@
     </Row>
 
     <AuthJanitor.UI.Components.HelpSlideInComponent Title="Resources"
-                                                    Icon="@FontAwesomeIcons.Database">
+                                                    Icon="@FontAwesomeIcons.Database"
+                                                    @bind-Visible="@ContextualHelpVisible">
         <p>
             <strong>Resources</strong> describe the configuration required to access a given service or object for the purposes
             of either delivering key/secret material or rekeying that object or service. A <strong>Resource</strong> is made up
@@ -90,7 +91,8 @@
                          ObjectName="@SelectedValue.Name"
                          ResultClicked="@DeleteConfirmCallback" />
 
-<SystemWideFooter RefreshDataClicked="@(() => LoadData())" />
+<SystemWideFooter RefreshDataClicked="@(() => LoadData())"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
 
 @using AuthJanitor.UI.Editors
 @using AuthJanitor.UI.Modals
@@ -99,6 +101,7 @@
 
     protected bool CreateModalShowing { get; set; }
     protected bool DeleteModalShowing { get; set; }
+    protected bool ContextualHelpVisible { get; set; }
 
     [Parameter]
     public ResourceViewModel SelectedValue { get; set; } = new ResourceViewModel();
@@ -106,7 +109,7 @@
     [Parameter]
     public EventCallback<ResourceViewModel> SelectedValueChanged { get; set; }
 
-    protected override Task OnInitializedAsync() => LoadData();
+    protected override async Task OnInitializedAsync() => await LoadData();
 
     protected async Task LoadData()
     {

--- a/src/AuthJanitor.AspNet.AdminUi/Shared/MainLayout.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Shared/MainLayout.razor
@@ -102,7 +102,6 @@
     protected override async Task OnInitializedAsync()
     {
         Metrics = await Http.AJGet<DashboardMetricsViewModel>();
-        await JSRuntime.InvokeVoidAsync("InitializeHelpSlideIn");
     }
 
     protected string GetGravatar()

--- a/src/AuthJanitor.AspNet.AdminUi/wwwroot/css/style.css
+++ b/src/AuthJanitor.AspNet.AdminUi/wwwroot/css/style.css
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) Microsoft Corporation. */
+/* Copyright (c) Microsoft Corporation. */
 /* Licensed under the MIT license. */
 .app-main {
     width: 100vw;
@@ -100,9 +100,12 @@ span.sectionHeader {
     padding: 0.25em 0.5em;
 }
 
+.providerImage {
+    -ms-flex: 0 0 6em;
+    flex: 0 0 6em;
+}
+
 /* -------------------------------------------------------------------------------- */
-
-
 
 
 

--- a/src/AuthJanitor.AspNet.AdminUi/wwwroot/index.html
+++ b/src/AuthJanitor.AspNet.AdminUi/wwwroot/index.html
@@ -85,15 +85,6 @@
     <script src="_content/BlazorTable/BlazorTable.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js"></script>
     <script src="_content/Blazorise.Charts/blazorise.charts.js"></script>
-
-    <script>
-        function InitializeHelpSlideIn() {
-            $("[data-toggle='toggle']").click(function () {
-                var selector = $(this).data("target");
-                $(selector).toggleClass('in');
-            });
-        }
-    </script>
 </body>
 
 </html>

--- a/src/AuthJanitor.AspNet/Models/Resource.cs
+++ b/src/AuthJanitor.AspNet/Models/Resource.cs
@@ -11,7 +11,6 @@ namespace AuthJanitor.UI.Shared.Models
         public string Name { get; set; }
         public string Description { get; set; }
 
-        public bool IsRekeyableObjectProvider { get; set; }
         public string ProviderType { get; set; }
         public string ProviderConfiguration { get; set; }
     }

--- a/src/AuthJanitor.AspNet/ViewModelFactory.cs
+++ b/src/AuthJanitor.AspNet/ViewModelFactory.cs
@@ -167,9 +167,8 @@ namespace AuthJanitor.UI.Shared
                 ObjectId = resource.ObjectId,
                 Name = resource.Name,
                 Description = resource.Description,
-                IsRekeyableObjectProvider = resource.IsRekeyableObjectProvider,
                 ProviderType = resource.ProviderType,
-                ProviderDetail = providerManagerService.GetProviderMetadata(resource.ProviderType).Details,
+                Provider = GetViewModel(serviceProvider, providerManagerService.GetProviderMetadata(resource.ProviderType)),
                 SerializedProviderConfiguration = resource.ProviderConfiguration,
                 RuntimeDescription = provider.GetDescription(),
                 Risks = provider.GetRisks()

--- a/src/AuthJanitor.AspNet/ViewModels/ManagedSecretViewModel.cs
+++ b/src/AuthJanitor.AspNet/ViewModels/ManagedSecretViewModel.cs
@@ -49,8 +49,8 @@ namespace AuthJanitor.UI.Shared.ViewModels
         public TimeSpan TimeRemaining => IsValid ? Expiry - DateTimeOffset.UtcNow : TimeSpan.Zero;
 
         [JsonIgnore]
-        public string ProviderSummary => $"{Resources.Count(r => !r.IsRekeyableObjectProvider)} ALCs, " +
-                                         $"{Resources.Count(r => r.IsRekeyableObjectProvider)} RKOs";
+        public string ProviderSummary => $"{Resources.Count(r => !r.Provider.IsRekeyableObjectProvider)} ALCs, " +
+                                         $"{Resources.Count(r => r.Provider.IsRekeyableObjectProvider)} RKOs";
 
         [JsonIgnore]
         public int ExpiryPercent => IsValid ?

--- a/src/AuthJanitor.AspNet/ViewModels/ResourceViewModel.cs
+++ b/src/AuthJanitor.AspNet/ViewModels/ResourceViewModel.cs
@@ -14,14 +14,8 @@ namespace AuthJanitor.UI.Shared.ViewModels
         public string Name { get; set; }
         public string Description { get; set; }
 
-        public bool IsRekeyableObjectProvider { get; set; }
         public string ProviderType { get; set; }
-        public ProviderAttribute ProviderDetail { get; set; } = new ProviderAttribute()
-        {
-            Name = "No Provider Loaded",
-            Description = "No Provider Loaded",
-            IconClass = "fa fa-times"
-        };
+        public LoadedProviderViewModel Provider { get; set; }
         public string SerializedProviderConfiguration { get; set; }
         public IEnumerable<RiskyConfigurationItem> Risks { get; set; } = new List<RiskyConfigurationItem>();
         public string RuntimeDescription { get; set; }

--- a/src/AuthJanitor.Core/Providers/ProviderAttribute.cs
+++ b/src/AuthJanitor.Core/Providers/ProviderAttribute.cs
@@ -24,11 +24,6 @@ namespace AuthJanitor.Providers
         public string Name { get; set; }
 
         /// <summary>
-        /// CSS class for Provider icons (FontAwesome 5)
-        /// </summary>
-        public string IconClass { get; set; }
-
-        /// <summary>
         /// Provider display description
         /// </summary>
         public string Description { get; set; }

--- a/src/AuthJanitor.Functions.AdminApi/Services/ResourcesService.cs
+++ b/src/AuthJanitor.Functions.AdminApi/Services/ResourcesService.cs
@@ -62,7 +62,6 @@ namespace AuthJanitor.Services
             {
                 Name = resource.Name,
                 Description = resource.Description,
-                IsRekeyableObjectProvider = provider.IsRekeyableObjectProvider,
                 ProviderType = provider.ProviderTypeName,
                 ProviderConfiguration = resource.SerializedProviderConfiguration
             };
@@ -135,7 +134,6 @@ namespace AuthJanitor.Services
                 ObjectId = resourceId,
                 Name = resource.Name,
                 Description = resource.Description,
-                IsRekeyableObjectProvider = resource.IsRekeyableObjectProvider,
                 ProviderType = resource.ProviderType,
                 ProviderConfiguration = resource.SerializedProviderConfiguration
             };

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ResourceConfiguration.cs
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/Configurations/ResourceConfiguration.cs
@@ -13,7 +13,6 @@ namespace AuthJanitor.Integrations.DataStores.EntityFrameworkCore.Configurations
             builder.HasKey(x => x.ObjectId);
             // TODO which properties are required?
             builder.Property(x => x.Name).IsRequired();
-            builder.Property(x => x.IsRekeyableObjectProvider).IsRequired();
             builder.Property(x => x.ProviderType).IsRequired();
         }
     }

--- a/src/AuthJanitor.Providers.AppServices/Functions/AppSettingsFunctionsApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/Functions/AppSettingsFunctionsApplicationLifecycleProvider.cs
@@ -15,7 +15,6 @@ namespace AuthJanitor.Providers.AppServices.Functions
     /// Defines a Functions application which receives key information through an AppConfig setting
     /// </summary>
     [Provider(Name = "Functions App - AppSettings",
-              IconClass = "fa fa-bolt",
               Description = "Manages the lifecycle of an Azure Functions app which reads a Managed Secret from its Application Settings",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable)]

--- a/src/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AppServices.Functions
 {
     [Provider(Name = "Functions App - Connection String",
-              IconClass = "fa fa-bolt",
               Description = "Manages the lifecycle of an Azure Functions app which reads from a Connection String",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable)]

--- a/src/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AppServices.Functions
 {
     [Provider(Name = "Functions App Key",
-              IconClass = "fa fa-key",
               Description = "Regenerates a Function Key for an Azure Functions application",
               Features = ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.FUNCTIONS_SVG)]

--- a/src/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AppServices.WebApps
 {
     [Provider(Name = "WebApp - AppSettings",
-              IconClass = "fa fa-globe",
               Description = "Manages the lifecycle of an Azure Web App which reads a Managed Secret from its Application Settings",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable)]

--- a/src/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AppServices.WebApps
 {
     [Provider(Name = "WebApp - Connection String",
-              IconClass = "fa fa-globe",
               Description = "Manages the lifecycle of an Azure Web App which reads from a Connection String",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable)]

--- a/src/AuthJanitor.Providers.AzureAD/AccessTokenRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AzureAD/AccessTokenRekeyableObjectProvider.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AzureAD
 {
     [Provider(Name = "Access Token",
-              IconClass = "fa fa-key",
               Description = "Acquires an Access Token from Azure AD with a given set of scopes",
               Features = ProviderFeatureFlags.None)]
     [ProviderImage(ProviderImages.AZURE_AD_SVG)]

--- a/src/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AzureMaps
 {
     [Provider(Name = "Azure Maps Key",
-              IconClass = "fa fa-map",
               Description = "Regenerates a key for an Azure Maps instance",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AzureSearch
 {
     [Provider(Name = "Azure Search Admin Key",
-              IconClass = "fas fa-search",
               Description = "Regenerates an Admin Key for an Azure Search service",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.AzureSql/AzureSqlAdministratorPasswordRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AzureSql/AzureSqlAdministratorPasswordRekeyableObjectProvider.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.AzureSql
 {
     [Provider(Name = "Azure SQL Server Administrator Password",
-          IconClass = "fas fa-database",
           Description = "Regenerates the administrator password of an Azure SQL Server",
           Features = ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.SQL_SERVER_SVG)]

--- a/src/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.CosmosDb
 {
     [Provider(Name = "CosmosDB Master Key",
-              IconClass = "fa fa-database",
               Description = "Regenerates a Master Key for an Azure CosmosDB instance",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.EventHub
 {
     [Provider(Name = "Event Hub Key",
-              IconClass = "fa fa-key",
               Description = "Regenerates an Azure Event Hub Key",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.KeyVault/KeyVaultKeyRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.KeyVault/KeyVaultKeyRekeyableObjectProvider.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.KeyVault
 {
     [Provider(Name = "Key Vault Key",
-              IconClass = "fa fa-key",
               Description = "Regenerates an Azure Key Vault Key with the same parameters as the previous version",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.KeyVault/KeyVaultSecretApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.KeyVault/KeyVaultSecretApplicationLifecycleProvider.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.KeyVault
 {
     [Provider(Name = "Key Vault Secret",
-              IconClass = "fa fa-low-vision",
               Description = "Manages the lifecycle of a Key Vault Secret where a Managed Secret's value is stored",
               Features = ProviderFeatureFlags.IsTestable)]
     [ProviderImage(ProviderImages.KEY_VAULT_SVG)]

--- a/src/AuthJanitor.Providers.KeyVault/KeyVaultSecretRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.KeyVault/KeyVaultSecretRekeyableObjectProvider.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.KeyVault
 {
     [Provider(Name = "Key Vault Secret",
-              IconClass = "fa fa-low-vision",
               Description = "Regenerates a Key Vault Secret with a given length",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.Redis
 {
     [Provider(Name = "Redis Cache Key",
-              IconClass = "fa fa-database",
               Description = "Regenerates a Master Key for a Redis Cache instance",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.ServiceBus
 {
     [Provider(Name = "Service Bus Key",
-              IconClass = "fa fa-key",
               Description = "Regenerates an Azure Service Bus Key",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime |
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
@@ -15,7 +15,6 @@ using System.Threading.Tasks;
 namespace AuthJanitor.Providers.Storage
 {
     [Provider(Name = "Storage Account Key",
-              IconClass = "fas fa-file-alt",
               Description = "Regenerates a key of a specified type for an Azure Storage Account",
               Features = ProviderFeatureFlags.CanRotateWithoutDowntime | 
                          ProviderFeatureFlags.IsTestable |

--- a/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ResourceTests.cs
+++ b/src/AuthJanitor.Tests/EntityFrameworkCoreDataStore/EF_ResourceTests.cs
@@ -13,7 +13,6 @@ namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
             {
                 ObjectId = Guid.NewGuid(),
                 Description = "Description",
-                IsRekeyableObjectProvider = true,
                 Name = "Name",
                 ProviderConfiguration = "ProviderConfiguration",
                 ProviderType = "ProviderType"
@@ -26,7 +25,6 @@ namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
             {
                 ObjectId = model.ObjectId,
                 Description = "Another Description",
-                IsRekeyableObjectProvider = false,
                 Name = "Another Name",
                 ProviderConfiguration = "Another ProviderConfiguration",
                 ProviderType = "Another ProviderType"
@@ -37,7 +35,6 @@ namespace AuthJanitor.Tests.EntityFrameworkCoreDataStore
         {
             if (model1.ObjectId != model2.ObjectId ||
                 model1.Description != model2.Description ||
-                model1.IsRekeyableObjectProvider != model2.IsRekeyableObjectProvider ||
                 model1.Name != model2.Name ||
                 model1.ProviderConfiguration != model2.ProviderConfiguration ||
                 model1.ProviderType != model2.ProviderType)


### PR DESCRIPTION
Displaying icons with providers didn't make sense once SVGs were introduced, so it makes better sense to standardize on that as a visual representation.

Also I felt compelled to yank out the problematic client-side JS in favor of data-bound contextual help visibility.