### PR TITLE
Add provider enumeration UI

### DIFF
--- a/src/AuthJanitor.AspNet.AdminUi/Components/SystemWideFooter.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Components/SystemWideFooter.razor
@@ -20,20 +20,23 @@
                         <i class="fa fa-sync-alt text-info"></i>
                     </a>
                 </div>
-                <div class="float-right mr-2">
-                    @if (Metrics.TasksInError > 0)
-                    {
-                        <a class="btn btn-sm btn-outline-danger mx-2" role="button" href="/rekeyingTasks">
-                            Errors <span class="badge badge-danger">@Metrics.TasksInError</span>
-                            <span class="sr-only">in rekeying tasks</span>
-                        </a>}
-                    @if (Metrics.TotalPendingApproval > 0)
-                    {
-                        <a class="btn btn-sm btn-outline-success mx-2" role="button" href="/rekeyingTasks">
-                            Approvals <span class="badge badge-success">@Metrics.TotalPendingApproval</span>
-                            <span class="sr-only">for pending rekeying tasks</span>
-                        </a>}
-                </div>
+                @if (Metrics != null)
+                {
+                    <div class="float-right mr-2">
+                        @if (Metrics.TasksInError > 0)
+                        {
+                            <a class="btn btn-sm btn-outline-danger mx-2" role="button" href="/rekeyingTasks">
+                                Errors <span class="badge badge-danger">@Metrics.TasksInError</span>
+                                <span class="sr-only">in rekeying tasks</span>
+                            </a>}
+                        @if (Metrics.TotalPendingApproval > 0)
+                        {
+                            <a class="btn btn-sm btn-outline-success mx-2" role="button" href="/rekeyingTasks">
+                                Approvals <span class="badge badge-success">@Metrics.TotalPendingApproval</span>
+                                <span class="sr-only">for pending rekeying tasks</span>
+                            </a>}
+                    </div>
+                }
             </div>
         </div>
     </div>
@@ -55,7 +58,8 @@
     protected void ChangeContextualHelpVisibility()
     {
         ContextualHelpVisible = !ContextualHelpVisible;
-        ContextualHelpVisibleChanged.InvokeAsync(ContextualHelpVisible);
+        if (!ContextualHelpVisibleChanged.Equals(default(EventCallback<bool>)))
+            ContextualHelpVisibleChanged.InvokeAsync(ContextualHelpVisible);
     }
 
     protected override async Task OnInitializedAsync()

--- a/src/AuthJanitor.AspNet.AdminUi/Pages/ProviderSuggestions.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Pages/ProviderSuggestions.razor
@@ -1,0 +1,91 @@
+﻿@page "/providers/suggestions"
+
+<Container Fluid="true" Style="position:relative;">
+    <AuthJanitor.UI.Components.BreadcrumbRow Category="Manage"
+                                             PageGroup="Resource Suggestions">
+        <Column ColumnSize="ColumnSize.Is3" Margin="Margin.IsAuto.OnY" Padding="Padding.Is3.FromRight" Class="text-right">
+            <Button Clicked="@(() => Enumerate())">
+                <Icon Name="@FontAwesomeIcons.SearchPlus" Margin="Margin.Is1.FromRight" />
+                Enumerate Services
+            </Button>
+        </Column>
+    </AuthJanitor.UI.Components.BreadcrumbRow>
+
+    <Row>
+        <Column Padding="Padding.Is0">
+            <BlazorTable.Table TableItem="ProviderResourceSuggestionViewModel"
+                               TableClass="table table-striped table-hover"
+                               @bind-Items="@Suggestions">
+
+                <!-- Resource Name -->
+                <BlazorTable.Column TableItem="ProviderResourceSuggestionViewModel"
+                                    Title="Name" Field="@(x => x.Name)"
+                                    Sortable="true" Filterable="true" />
+
+                <!-- Provider -->
+                <BlazorTable.Column TableItem="ProviderResourceSuggestionViewModel"
+                                    Title="Provider" Field="@(x => x.ProviderType)"
+                                    Sortable="true" Filterable="true">
+                    <Template>
+                        @{ 
+                            var provider = _providers.FirstOrDefault(p => p.ProviderTypeName == context.ProviderType); }
+                        @if (provider != null)
+                        {
+                            <span class="float-left mr-2" style="width:1em;">
+                                @((MarkupString)provider.Details.SvgImage)
+                            </span>
+                            @provider.Details.Name
+                        }
+                        else
+                        {
+                            <p>Error Identifying Provider <strong>@context.ProviderType</strong>!</p>
+                        }
+                    </Template>
+                </BlazorTable.Column>
+
+                <!-- Provider Config -->
+                <BlazorTable.Column TableItem="ProviderResourceSuggestionViewModel"
+                                    Title="Configuration" Field="@(x => x.ProviderConfiguration)"
+                                    Sortable="true" Filterable="true">
+                    <Template>
+                        <AuthJanitor.UI.Components.ConfigurationVisualizer ShowEditControls="false" Value="@context.ProviderConfiguration" />
+                    </Template>
+                </BlazorTable.Column>
+
+                <!-- Pager -->
+                <BlazorTable.Pager ShowPageNumber="true" ShowTotalCount="true" />
+            </BlazorTable.Table>
+        </Column>
+    </Row>
+
+    <AuthJanitor.UI.Components.HelpSlideInComponent Title="Resource Suggestions"
+                                                    Icon="@FontAwesomeIcons.SearchPlus"
+                                                    @bind-Visible="@ContextualHelpVisible">
+        <p>
+            <strong>Resource Suggestions</strong> are derived from your currently logged in user's Azure services. AuthJanitor
+            will scan all available services for ones which are supported by a loaded <strong>Provider</strong> and suggest
+            possible configurations for new <strong>Resources</strong> here.
+        </p>
+    </AuthJanitor.UI.Components.HelpSlideInComponent>
+</Container>
+
+<SystemWideFooter RefreshDataClicked="@(async () => { await Enumerate(); })"
+                  @bind-ContextualHelpVisible="@ContextualHelpVisible"/>
+
+@using AuthJanitor.ViewModels 
+@code {
+    protected IEnumerable<ProviderResourceSuggestionViewModel> Suggestions { get; set; } = new List<ProviderResourceSuggestionViewModel>();
+
+    private IEnumerable<LoadedProviderViewModel> _providers = new LoadedProviderViewModel[0];
+    protected bool ContextualHelpVisible { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _providers = await Http.AJList<LoadedProviderViewModel>();
+    }
+
+    protected async Task Enumerate()
+    {
+        Suggestions = await Http.AJList<ProviderResourceSuggestionViewModel>("enumerate");
+    }
+}

--- a/src/AuthJanitor.AspNet.AdminUi/Shared/MainLayout.razor
+++ b/src/AuthJanitor.AspNet.AdminUi/Shared/MainLayout.razor
@@ -25,6 +25,8 @@
                         <div class="dropdown-menu dropdown-menu-left" aria-labelledby="navbarManageDropdown">
                             <a class="dropdown-item" href="/dashboard"><i class="fa fa-tachometer-alt mr-3"></i>Dashboard</a>
                             <div class="dropdown-divider"></div>
+                            <a class="dropdown-item" href="/providers/suggestions"><i class="fa fa-search mr-3"></i>Enumerated Resources</a>
+                            <div class="dropdown-divider"></div>
                             <a class="dropdown-item" href="/resources"><i class="fa fa-database mr-3"></i>Resources</a>
                             <a class="dropdown-item" href="/managedSecrets"><i class="fa fa-key mr-3"></i>Secrets</a>
                             <a class="dropdown-item" href="/rekeyingTasks"><i class="fa fa-tasks mr-3"></i>Rekeying Tasks</a>

--- a/src/AuthJanitor.AspNet/AuthJanitorHttpClient.cs
+++ b/src/AuthJanitor.AspNet/AuthJanitorHttpClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using AuthJanitor.UI.Shared.ViewModels;
+using AuthJanitor.ViewModels;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -22,7 +23,8 @@ namespace AuthJanitor.UI.Shared
             { typeof(ResourceViewModel), "resources" },
             { typeof(LoadedProviderViewModel), "providers" },
             { typeof(ProviderConfigurationViewModel), "providers" },
-            { typeof(AuthJanitorAuthorizedUserViewModel), "access" }
+            { typeof(AuthJanitorAuthorizedUserViewModel), "access" },
+            { typeof(ProviderResourceSuggestionViewModel), "providers" }
         };
 
         public AuthJanitorHttpClient() : base()
@@ -62,6 +64,12 @@ namespace AuthJanitor.UI.Shared
         public Task<IEnumerable<T>> AJList<T>() where T : IAuthJanitorViewModel => this
             .AssertRequestIsSane<T>()
             .GetAsync($"{BaseAddress}/{ApiFormatStrings[typeof(T)]}")
+            .ContinueWith(t => GetFromContentPayload<IEnumerable<T>>(t.Result))
+            .Unwrap();
+
+        public Task<IEnumerable<T>> AJList<T>(string objectName) where T : IAuthJanitorViewModel => this
+            .AssertRequestIsSane<T>()
+            .GetAsync($"{BaseAddress}/{ApiFormatStrings[typeof(T)]}/{objectName}")
             .ContinueWith(t => GetFromContentPayload<IEnumerable<T>>(t.Result))
             .Unwrap();
 

--- a/src/AuthJanitor.AspNet/ViewModels/ProviderResourceSuggestionViewModel.cs
+++ b/src/AuthJanitor.AspNet/ViewModels/ProviderResourceSuggestionViewModel.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+using AuthJanitor.UI.Shared.ViewModels;
+
+namespace AuthJanitor.ViewModels
+{
+    public class ProviderResourceSuggestionViewModel : IAuthJanitorViewModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public string ProviderType { get; set; } = string.Empty;
+        public string ProviderConfigurationSerialized { get; set; } = string.Empty;
+        public ProviderConfigurationViewModel ProviderConfiguration { get; set; }
+    }
+}

--- a/src/AuthJanitor.Core/Providers/Capabilities/IAuthJanitorCapability.cs
+++ b/src/AuthJanitor.Core/Providers/Capabilities/IAuthJanitorCapability.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 namespace AuthJanitor.Providers.Capabilities
 {
     public interface IAuthJanitorCapability : IAuthJanitorProvider { }

--- a/src/AuthJanitor.Core/Providers/Capabilities/ICanEnumerateResourceCandidates.cs
+++ b/src/AuthJanitor.Core/Providers/Capabilities/ICanEnumerateResourceCandidates.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-using AuthJanitor.Providers;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,6 +7,6 @@ namespace AuthJanitor.Providers.Capabilities
 {
     public interface ICanEnumerateResourceCandidates : IAuthJanitorCapability
     {
-        Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig);
+        Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig);
     }
 }

--- a/src/AuthJanitor.Core/Providers/ProviderResourceSuggestion.cs
+++ b/src/AuthJanitor.Core/Providers/ProviderResourceSuggestion.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+namespace AuthJanitor.Providers
+{
+    public class ProviderResourceSuggestion
+    {
+        public string Name { get; set; }
+        public string ProviderType { get; set; }
+
+        public AuthJanitorProviderConfiguration Configuration { get; set; }
+        public string SerializedConfiguration { get; set; }
+    }
+}

--- a/src/AuthJanitor.Functions.AdminApi/Functions/Providers.cs
+++ b/src/AuthJanitor.Functions.AdminApi/Functions/Providers.cs
@@ -28,6 +28,12 @@ namespace AuthJanitor.Functions
             return _service.List(req);
         }
 
+        [FunctionName("Providers-Enumerate")]
+        public async Task<IActionResult> Enumerate([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "providers/enumerate")] HttpRequest req)
+        {
+            return await _service.Enumerate(req);
+        }
+
         [FunctionName("Providers-GetBlankConfiguration")]
         public async Task<IActionResult> GetBlankConfiguration(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "providers/{providerType}")] HttpRequest req,

--- a/src/AuthJanitor.Functions.AdminApi/Services/ProvidersService.cs
+++ b/src/AuthJanitor.Functions.AdminApi/Services/ProvidersService.cs
@@ -8,13 +8,13 @@ using AuthJanitor.IdentityServices;
 using AuthJanitor.Providers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
 using AuthJanitor.Providers.Capabilities;
+using AuthJanitor.ViewModels;
+using Microsoft.Extensions.Logging;
 
 namespace AuthJanitor.Services
 {
@@ -25,6 +25,7 @@ namespace AuthJanitor.Services
     public class ProvidersService
     {
         private readonly IIdentityService _identityService;
+        private readonly ILogger _logger;
         private readonly EventDispatcherMetaService _eventDispatcher;
         private readonly ProviderManagerService _providerManager;
 
@@ -33,12 +34,14 @@ namespace AuthJanitor.Services
 
         public ProvidersService(
             IIdentityService identityService,
+            ILogger<ProvidersService> logger,
             EventDispatcherMetaService eventDispatcher,
             ProviderManagerService providerManager,
             Func<AuthJanitorProviderConfiguration, ProviderConfigurationViewModel> configViewModelDelegate,
             Func<LoadedProviderMetadata, LoadedProviderViewModel> providerViewModelDelegate)
         {
             _identityService = identityService;
+            _logger = logger;
             _eventDispatcher = eventDispatcher;
             _providerManager = providerManager;
 
@@ -53,6 +56,41 @@ namespace AuthJanitor.Services
             if (!_identityService.IsUserLoggedIn) return new UnauthorizedResult();
 
             return new OkObjectResult(_providerManager.LoadedProviders.Select(p => _providerViewModel(p)));
+        }
+
+        public async Task<IActionResult> Enumerate(HttpRequest req)
+        {
+            _ = req;
+
+            if (!_identityService.IsUserLoggedIn) return new UnauthorizedResult();
+
+            _logger.LogInformation("Acquiring OBO token");
+            var token = await _identityService.GetAccessTokenOnBehalfOfCurrentUserAsync();
+
+            _logger.LogInformation("Starting provider enumeration");
+            var providerSuggestions = await _providerManager.EnumerateProviders(token);
+
+            _logger.LogInformation("Enumerated {Count} provider suggestions", providerSuggestions.Count());
+
+            var results = new System.Collections.Generic.List<ProviderResourceSuggestionViewModel>();
+            return new OkObjectResult(providerSuggestions.Select(p =>
+            {
+                try
+                {
+                    return new ProviderResourceSuggestionViewModel()
+                    {
+                        Name = p.Name,
+                        ProviderType = p.ProviderType,
+                        ProviderConfiguration = _configViewModel(p.Configuration),
+                        ProviderConfigurationSerialized = p.SerializedConfiguration
+                    };
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error preparing suggestion: " + ex.ToString());
+                    return null;
+                }
+            }).Where(s => s != null));
         }
 
         public async Task<IActionResult> GetBlankConfiguration(HttpRequest req, string providerType)

--- a/src/AuthJanitor.Functions.AdminApi/proxies.json
+++ b/src/AuthJanitor.Functions.AdminApi/proxies.json
@@ -17,6 +17,10 @@
       "matchCondition": { "route": "/providers" },
       "backendUri": "%STORAGE_WEB_URL%/providers"
     },
+    "ui-providers-suggestions": {
+      "matchCondition": { "route": "/providers/suggestions" },
+      "backendUri": "%STORAGE_WEB_URL%/providers/suggestions"
+    },
     "ui-integrityReports": {
       "matchCondition": { "route": "/integrityReports" },
       "backendUri": "%STORAGE_WEB_URL%/integrityReports"

--- a/src/AuthJanitor.Functions.Agent/AuthJanitor.Functions.Agent.csproj
+++ b/src/AuthJanitor.Functions.Agent/AuthJanitor.Functions.Agent.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <Configurations>Debug;Release</Configurations>
     <RootNamespace>AuthJanitor</RootNamespace>

--- a/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitor.Integrations.DataStores.EntityFrameworkCore.csproj
+++ b/src/AuthJanitor.Integrations.DataStores.EntityFrameworkCore/AuthJanitor.Integrations.DataStores.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/Functions/ConnectionStringFunctionsApplicationLifecycleProvider.cs
@@ -66,7 +66,7 @@ namespace AuthJanitor.Providers.AppServices.Functions
             $"be moved from slot '{Configuration.SourceSlot}' to slot '{Configuration.TemporarySlot}' " +
             $"temporarily, and then back.";
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -79,13 +79,18 @@ namespace AuthJanitor.Providers.AppServices.Functions
             return (await Task.WhenAll(items.Select(async i =>
             {
                 return (await i.GetConnectionStringsAsync()).Select(c =>
-                new ConnectionStringConfiguration()
+                new ProviderResourceSuggestion()
                 {
-                    ResourceName = i.Name,
-                    ResourceGroup = i.ResourceGroupName,
-                    ConnectionStringName = c.Key,
-                    ConnectionStringType = c.Value.Type
-                } as AuthJanitorProviderConfiguration);
+                    Configuration = new ConnectionStringConfiguration()
+                    {
+                        ResourceName = i.Name,
+                        ResourceGroup = i.ResourceGroupName,
+                        ConnectionStringName = c.Key,
+                        ConnectionStringType = c.Value.Type
+                    },
+                    Name = $"Functions/ConnStr - {i.ResourceGroupName} - {i.Name} ({c.Key})",
+                    ProviderType = this.GetType().AssemblyQualifiedName
+                });
             }))).SelectMany(f => f).ToList();
         }
     }

--- a/src/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/Functions/FunctionKeyRekeyableObjectProvider.cs
@@ -75,7 +75,7 @@ namespace AuthJanitor.Providers.AppServices.Functions
 
         protected override ISupportsGettingByResourceGroup<IFunctionApp> GetResourceCollection(IAzure azure) => azure.AppServices.FunctionApps;
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
             
@@ -85,23 +85,33 @@ namespace AuthJanitor.Providers.AppServices.Functions
             else
                 items = await (await GetAzureAsync()).AppServices.FunctionApps.ListAsync();
 
-            return (await Task.WhenAll<List<AuthJanitorProviderConfiguration>>(items.Select(async i =>
+            return (await Task.WhenAll(items.Select(async i =>
             {
-                var items = new List<AuthJanitorProviderConfiguration>();
-                foreach (var func in await i.ListFunctionsAsync())
+                var items = new List<ProviderResourceSuggestion>();
+                try
                 {
-                    foreach (var key in await i.ListFunctionKeysAsync(func.Name))
+                    foreach (var func in await i.ListFunctionsAsync())
                     {
-                        items.Add(new FunctionKeyConfiguration()
+                        foreach (var key in await i.ListFunctionKeysAsync(func.Name))
                         {
-                            ResourceName = i.Name,
-                            ResourceGroup = i.ResourceGroupName,
-                            FunctionName = func.Name,
-                            FunctionKeyName = key.Key,
-                            KeyLength = key.Value.Length > 10 ? key.Value.Length : 32
-                        });
+                            items.Add(
+                                new ProviderResourceSuggestion()
+                                {
+                                    Configuration = new FunctionKeyConfiguration()
+                                    {
+                                        ResourceName = i.Name,
+                                        ResourceGroup = i.ResourceGroupName,
+                                        FunctionName = func.Name,
+                                        FunctionKeyName = key.Key,
+                                        KeyLength = key.Value.Length > 10 ? key.Value.Length : 32
+                                    },
+                                    Name = $"Function Key - {i.ResourceGroupName} - {i.Name} - {func.Name} ({key.Key})",
+                                    ProviderType = this.GetType().AssemblyQualifiedName
+                                });
+                        }
                     }
                 }
+                catch (Exception) { }
                 return items;
             }))).SelectMany(f => f).ToList();
         }

--- a/src/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/WebApps/AppSettingsWebAppApplicationLifecycleProvider.cs
@@ -66,7 +66,7 @@ namespace AuthJanitor.Providers.AppServices.WebApps
             $"be moved from slot '{Configuration.SourceSlot}' to slot '{Configuration.TemporarySlot}' " +
             $"temporarily, and then back.";
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -79,13 +79,18 @@ namespace AuthJanitor.Providers.AppServices.WebApps
             return (await Task.WhenAll(items.Select(async i =>
             {
                 return (await i.GetAppSettingsAsync()).Select(c =>
-                new AppSettingConfiguration()
+                new ProviderResourceSuggestion()
                 {
-                    ResourceName = i.Name,
-                    ResourceGroup = i.ResourceGroupName,
-                    // TODO: CommitAsConnectionString?
-                    SettingName = c.Key
-                } as AuthJanitorProviderConfiguration);
+                    Configuration = new AppSettingConfiguration()
+                    {
+                        ResourceName = i.Name,
+                        ResourceGroup = i.ResourceGroupName,
+                        // TODO: CommitAsConnectionString?
+                        SettingName = c.Key
+                    },
+                    Name = $"WebApp/AppSettings - {i.ResourceGroupName} - {i.Name}",
+                    ProviderType = this.GetType().AssemblyQualifiedName
+                });
             }))).SelectMany(f => f).ToList();
         }
     }

--- a/src/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
+++ b/src/AuthJanitor.Providers.AppServices/WebApps/ConnectionStringWebAppApplicationLifecycleProvider.cs
@@ -65,7 +65,7 @@ namespace AuthJanitor.Providers.AppServices.WebApps
             $"be moved from slot '{Configuration.SourceSlot}' to slot '{Configuration.TemporarySlot}' " +
             $"temporarily, and then back.";
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -78,13 +78,18 @@ namespace AuthJanitor.Providers.AppServices.WebApps
             return (await Task.WhenAll(items.Select(async i =>
             {
                 return (await i.GetConnectionStringsAsync()).Select(c =>
-                new ConnectionStringConfiguration()
+                new ProviderResourceSuggestion()
                 {
-                    ResourceName = i.Name,
-                    ResourceGroup = i.ResourceGroupName,
-                    ConnectionStringName = c.Key,
-                    ConnectionStringType = c.Value.Type
-                } as AuthJanitorProviderConfiguration);
+                    Configuration = new ConnectionStringConfiguration()
+                    {
+                        ResourceName = i.Name,
+                        ResourceGroup = i.ResourceGroupName,
+                        ConnectionStringName = c.Key,
+                        ConnectionStringType = c.Value.Type
+                    },
+                    Name = $"WebApp/ConnStr - {i.ResourceGroupName} - {i.Name} ({c.Key})",
+                    ProviderType = this.GetType().AssemblyQualifiedName
+                });
             }))).SelectMany(f => f).ToList();
         }
     }

--- a/src/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AzureMaps/AzureMapsRekeyableObjectProvider.cs
@@ -118,7 +118,7 @@ namespace AuthJanitor.Providers.AzureMaps
             _ => throw new NotImplementedException()
         };
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -129,11 +129,16 @@ namespace AuthJanitor.Providers.AzureMaps
                 items = await ManagementClient.Accounts.ListBySubscriptionAsync();
 
             return items.Select(i =>
-                new AzureMapsConfiguration()
+            new ProviderResourceSuggestion()
+            {
+                Configuration = new AzureMapsConfiguration()
                 {
                     ResourceName = i.Name,
                     KeyType = AzureMapsConfiguration.AzureMapsKeyType.Primary
-                } as AuthJanitorProviderConfiguration).ToList();
+                },
+                Name = $"Azure Maps - {i.Name}",
+                ProviderType = this.GetType().AssemblyQualifiedName
+            }).ToList();
         }
 
         private string GetKeyType => Configuration.KeyType switch

--- a/src/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AzureSearch/AzureSearchAdminKeyRekeyableObjectProvider.cs
@@ -51,7 +51,7 @@ namespace AuthJanitor.Providers.AzureSearch
 
         protected override ISupportsGettingByResourceGroup<ISearchService> GetResourceCollection(IAzure azure) => azure.SearchServices;
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -61,12 +61,17 @@ namespace AuthJanitor.Providers.AzureSearch
             else
                 items = await (await GetAzureAsync()).SearchServices.ListAsync();
 
-            return items.Select(i => new AzureSearchAdminKeyConfiguration()
+            return items.Select(i => new ProviderResourceSuggestion()
             {
-                ResourceGroup = i.ResourceGroupName,
-                ResourceName = i.Name,
-                KeyType = AzureSearchAdminKeyConfiguration.AzureSearchKeyKinds.Primary
-            } as AuthJanitorProviderConfiguration).ToList();
+                Configuration = new AzureSearchAdminKeyConfiguration()
+                {
+                    ResourceGroup = i.ResourceGroupName,
+                    ResourceName = i.Name,
+                    KeyType = AzureSearchAdminKeyConfiguration.AzureSearchKeyKinds.Primary
+                },
+                Name = $"Azure Search - {i.ResourceGroupName} - {i.Name}",
+                ProviderType = this.GetType().AssemblyQualifiedName
+            }).ToList();
         }
     }
 }

--- a/src/AuthJanitor.Providers.AzureSql/AzureSqlAdministratorPasswordRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.AzureSql/AzureSqlAdministratorPasswordRekeyableObjectProvider.cs
@@ -120,7 +120,7 @@ namespace AuthJanitor.Providers.AzureSql
 
         protected override ISupportsGettingByResourceGroup<ISqlServer> GetResourceCollection(IAzure azure) => azure.SqlServers;
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -133,13 +133,18 @@ namespace AuthJanitor.Providers.AzureSql
             return (await Task.WhenAll(items.Select(async i =>
             {
                 return (await i.Databases.ListAsync()).Select(db =>
-                    new AzureSqlAdministratorPasswordConfiguration()
+                new ProviderResourceSuggestion()
+                {
+                    Configuration = new AzureSqlAdministratorPasswordConfiguration()
                     {
                         ResourceGroup = i.ResourceGroupName,
                         ResourceName = i.Name,
                         DatabaseName = db.Name,
                         PasswordLength = 32
-                    } as AuthJanitorProviderConfiguration);
+                    },
+                    Name = $"SQL Admin - {i.ResourceGroupName} - {i.Name} (DB: {db.Name})",
+                    ProviderType = this.GetType().AssemblyQualifiedName
+                });
             }))).SelectMany(f => f).ToList();
         }
     }

--- a/src/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.CosmosDb/CosmosDbRekeyableObjectProvider.cs
@@ -31,7 +31,7 @@ namespace AuthJanitor.Providers.CosmosDb
 
         protected override string Service => "CosmosDB";
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -42,12 +42,17 @@ namespace AuthJanitor.Providers.CosmosDb
                 items = await (await GetAzureAsync()).CosmosDBAccounts.ListAsync();
 
             return items.Select(i =>
-                new CosmosDbKeyConfiguration()
+            new ProviderResourceSuggestion()
+            {
+                Configuration = new CosmosDbKeyConfiguration()
                 {
                     ResourceGroup = i.ResourceGroupName,
                     ResourceName = i.Name,
                     KeyType = CosmosDbKeyConfiguration.CosmosDbKeyKinds.Primary,
-                } as AuthJanitorProviderConfiguration).ToList();
+                },
+                Name = $"CosmosDB - {i.ResourceGroupName} - {i.Name}",
+                ProviderType = this.GetType().AssemblyQualifiedName
+            }).ToList();
         }
 
         protected override RegeneratedSecret CreateSecretFromKeyring(IDatabaseAccountListKeysResult keyring, CosmosDbKeyConfiguration.CosmosDbKeyKinds keyType) =>

--- a/src/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.EventHub/EventHubRekeyableObjectProvider.cs
@@ -28,7 +28,7 @@ namespace AuthJanitor.Providers.EventHub
 
         protected override string Service => "Event Hub";
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -45,13 +45,18 @@ namespace AuthJanitor.Providers.EventHub
                 {
                     var rules = await eh.ListAuthorizationRulesAsync();
                     return rules.Select(rule =>
-                        new EventHubKeyConfiguration()
+                    new ProviderResourceSuggestion()
+                    {
+                        Configuration = new EventHubKeyConfiguration()
                         {
                             ResourceGroup = i.ResourceGroupName,
                             ResourceName = eh.Name,
                             NamespaceName = eh.NamespaceName,
                             AuthorizationRuleName = rule.Name
-                        } as AuthJanitorProviderConfiguration);
+                        },
+                        Name = $"Event Hub Key - {i.ResourceGroupName} - {eh.Name} - {eh.NamespaceName} ({rule.Name})",
+                        ProviderType = this.GetType().AssemblyQualifiedName
+                    });
                 }))).SelectMany(f => f);
             }))).SelectMany(f => f).ToList();
         }

--- a/src/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.RedisCache/RedisCacheKeyRekeyableObjectProvider.cs
@@ -53,7 +53,7 @@ namespace AuthJanitor.Providers.Redis
             _ => throw new NotImplementedException()
         };
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -64,12 +64,17 @@ namespace AuthJanitor.Providers.Redis
                 items = await (await GetAzureAsync()).RedisCaches.ListAsync();
 
             return items.Select(i =>
-                new RedisCacheKeyConfiguration()
+            new ProviderResourceSuggestion()
+            {
+                Configuration = new RedisCacheKeyConfiguration()
                 {
                     ResourceGroup = i.ResourceGroupName,
                     ResourceName = i.Name,
                     KeyType = RedisCacheKeyConfiguration.RedisKeyTypes.Primary
-                } as AuthJanitorProviderConfiguration).ToList();
+                },
+                Name = $"Redis Cache - {i.ResourceGroupName} - {i.Name}",
+                ProviderType = this.GetType().AssemblyQualifiedName
+            }).ToList();
         }
     }
 }

--- a/src/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.ServiceBus/ServiceBusRekeyableObjectProvider.cs
@@ -59,7 +59,7 @@ namespace AuthJanitor.Providers.ServiceBus
 
         protected override ISupportsGettingByResourceGroup<IServiceBusNamespace> GetResourceCollection(IAzure azure) => azure.ServiceBusNamespaces;
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -73,13 +73,18 @@ namespace AuthJanitor.Providers.ServiceBus
             {
                 var rules = await i.AuthorizationRules.ListAsync();
                 return rules.Select(rule =>
-                    new ServiceBusKeyConfiguration()
+                new ProviderResourceSuggestion()
+                {
+                    Configuration = new ServiceBusKeyConfiguration()
                     {
                         ResourceGroup = i.ResourceGroupName,
                         ResourceName = i.Name,
                         AuthorizationRuleName = rule.Name,
                         KeyType = ServiceBusKeyConfiguration.ServiceBusKeyTypes.Primary
-                    } as AuthJanitorProviderConfiguration);
+                    },
+                    Name = $"Service Bus Key - {i.ResourceGroupName} - {i.Name} ({rule.Name})",
+                    ProviderType = this.GetType().AssemblyQualifiedName
+                });
             }))).SelectMany(f => f).ToList();
         }
     }

--- a/src/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
+++ b/src/AuthJanitor.Providers.Storage/StorageAccountRekeyableObjectProvider.cs
@@ -32,7 +32,7 @@ namespace AuthJanitor.Providers.Storage
 
         protected override string Service => "Storage";
 
-        public async Task<List<AuthJanitorProviderConfiguration>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
+        public async Task<List<ProviderResourceSuggestion>> EnumerateResourceCandidates(AuthJanitorProviderConfiguration baseConfig)
         {
             var azureConfig = baseConfig as AzureAuthJanitorProviderConfiguration;
 
@@ -43,11 +43,16 @@ namespace AuthJanitor.Providers.Storage
                 items = await (await GetAzureAsync()).StorageAccounts.ListAsync();
 
             return items.Select(i =>
-                new StorageAccountKeyConfiguration()
+            new ProviderResourceSuggestion()
+            {
+                Configuration = new StorageAccountKeyConfiguration()
                 {
                     ResourceGroup = i.ResourceGroupName,
                     ResourceName = i.Name
-                } as AuthJanitorProviderConfiguration).ToList();
+                },
+                Name = $"Storage Account - {i.ResourceGroupName} - {i.Name}",
+                ProviderType = this.GetType().AssemblyQualifiedName
+            }).ToList();
         }
 
         protected override RegeneratedSecret CreateSecretFromKeyring(IReadOnlyList<StorageAccountKey> keyring, StorageAccountKeyConfiguration.StorageKeyTypes keyType)


### PR DESCRIPTION
Linked to #100 with some changes to that logic.

Services include logic to enumerate services based on a base configuration (which is currently unused) and the OBO token from the user.

Names are naive but generated by the providers themselves, so they're descriptive and flexible.

This is really cool and opens up some awesome user-friendly configuration options! 😄 